### PR TITLE
make name an optional parameter to fuzzy_assert_proportion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -37,13 +37,13 @@ jobs:
           pip install black==22.3.0 isort
           black . --check --diff
           isort . --check --verbose --only-modified --diff
-      # - name: Test
-      #   run: |
-      #     if "${{ github.event_name == 'schedule' }}"; then
-      #       pytest --runslow ./tests
-      #     else
-      #       pytest ./tests
-      #     fi
+      - name: Test
+        run: |
+         if "${{ github.event_name == 'schedule' }}"; then
+           pytest --runslow ./tests
+         else
+           pytest ./tests
+         fi
       # - name: Doc build
       #   run: |
       #     make html -C docs/ SPHINXOPTS="-W --keep-going -n"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.0.1 - 10/14/24**
+
+ - Make name an optional parameter to fuzzy_assert_proportion
+
 **1.0.0 - 03/01/24**
 
  - Repository creation

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
-**1.0.1 - 10/14/24**
+**0.1.1 - 10/14/24**
 
  - Make name an optional parameter to fuzzy_assert_proportion
 
-**1.0.0 - 03/01/24**
+**0.1.0 - 03/01/24**
 
  - Repository creation

--- a/src/vivarium_testing_utils/fuzzy_checker.py
+++ b/src/vivarium_testing_utils/fuzzy_checker.py
@@ -2,11 +2,10 @@
 # Fuzzy Checker #
 #################
 
-import os
 import warnings
 from functools import cache
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -50,13 +49,13 @@ class FuzzyChecker:
 
     def fuzzy_assert_proportion(
         self,
-        name: str,
         observed_numerator: int,
         observed_denominator: int,
         target_proportion: Union[Tuple[float, float], float],
         fail_bayes_factor_cutoff: float = 100.0,
         inconclusive_bayes_factor_cutoff: float = 0.1,
         bug_issue_beta_distribution_parameters: Tuple[float, float] = (0.5, 0.5),
+        name: str = "",
         name_additional: str = "",
     ) -> None:
         """
@@ -72,10 +71,6 @@ class FuzzyChecker:
         See more detail about the statistics used here:
         https://vivarium-research.readthedocs.io/en/latest/model_design/vivarium_features/automated_v_and_v/index.html#proportions-and-rates
 
-        :param name:
-            The name of the assertion, for use in messages and diagnostics.
-            All assertions with the same name will output identical warning messages,
-            which means pytest will aggregate those warnings.
         :param observed_numerator:
             The observed number of events.
         :param observed_denominator:
@@ -108,6 +103,10 @@ class FuzzyChecker:
             more mass around 0 and 1.
             Generally the default should be used in most circumstances; changing it is probably a
             research decision.
+        :param name:
+            The name of the assertion, for use in messages and diagnostics.
+            All assertions with the same name will output identical warning messages,
+            which means pytest will aggregate those warnings.
         :param name_additional:
             An optional additional name attribute that will be output in diagnostics but not in warnings.
             Useful for e.g. specifying the timestep when an assertion happened.

--- a/src/vivarium_testing_utils/fuzzy_checker.py
+++ b/src/vivarium_testing_utils/fuzzy_checker.py
@@ -1,11 +1,11 @@
 #################
 # Fuzzy Checker #
 #################
+from __future__ import annotations
 
 import warnings
 from functools import cache
 from pathlib import Path
-from typing import Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -51,10 +51,10 @@ class FuzzyChecker:
         self,
         observed_numerator: int,
         observed_denominator: int,
-        target_proportion: Union[Tuple[float, float], float],
+        target_proportion: tuple[float, float] | float,
         fail_bayes_factor_cutoff: float = 100.0,
         inconclusive_bayes_factor_cutoff: float = 0.1,
-        bug_issue_beta_distribution_parameters: Tuple[float, float] = (0.5, 0.5),
+        bug_issue_beta_distribution_parameters: tuple[float, float] = (0.5, 0.5),
         name: str = "",
         name_additional: str = "",
     ) -> None:
@@ -217,7 +217,7 @@ class FuzzyChecker:
     @cache
     def _fit_beta_distribution_to_uncertainty_interval(
         self, lower_bound: float, upper_bound: float
-    ) -> Tuple[float, float]:
+    ) -> tuple[float, float]:
         """
         Finds a and b parameters of a beta distribution that approximates the specified 95% UI.
         The overall approach was inspired by https://stats.stackexchange.com/a/112671/.
@@ -253,7 +253,7 @@ class FuzzyChecker:
         the bounds themselves (or the difference between them) are only a few orders of magnitude
         larger than the floating point precision.
         """
-        assert lower_bound > 0 and upper_bound < 1 and upper_bound > lower_bound
+        assert 0 < lower_bound < upper_bound < 1
 
         concentration_max = 1e40
         concentration_min = 1e-3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/tests/test_fuzzy_checker.py
+++ b/tests/test_fuzzy_checker.py
@@ -1,0 +1,4 @@
+# TODO: Add tests for fuzzy_checker
+
+def test_placeholder():
+    assert True

--- a/tests/test_fuzzy_checker.py
+++ b/tests/test_fuzzy_checker.py
@@ -2,6 +2,6 @@
 import pytest
 
 
-@pytest.skip("TODO - MIC-5419: Add tests for fuzzy_checker")
+@pytest.mark.skip("TODO - MIC-5419: Add tests for fuzzy_checker")
 def test_placeholder():
     assert True

--- a/tests/test_fuzzy_checker.py
+++ b/tests/test_fuzzy_checker.py
@@ -1,4 +1,7 @@
 # TODO: Add tests for fuzzy_checker
+import pytest
 
+
+@pytest.skip("TODO - MIC-5419: Add tests for fuzzy_checker")
 def test_placeholder():
     assert True


### PR DESCRIPTION
## Make name an optional parameter to fuzzy_assert_proportion
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5412

### Changes and notes
- Make name an optional parameter to fuzzy_assert_proportion 
- Bring existing type hints in line with PEP 585
- Run pytests on builds

Notes:
- These changes are not backwards compatible for calls using name
  as a positional argument
- While pseudopeople and the prl sim should be using this repo, they 
  aren't at this time. Tickets have been created to have this happen
- I think our original version of this should not have been 1.0.0, since
  that implies a degree of maturity that this repo doesn't have. I suggest
  deleting that version on PyPI and calling this version 0.1.1

### Testing
N/A
