### PR TITLE
Drop support for python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
     uses: 
       ihmeuw/vivarium_build_utils/.github/workflows/build.yml@main
     with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.2.0 - 11/21/24**
+
+ - Drop support for Python 3.9
+
 **0.1.2 - 10/31/24**
 
  - Add mypy type checking

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ pipeline {
           axis {
               // parallelize by python minor version
               name 'PYTHON_VERSION'
-              values "3.9", "3.10", "3.11"
+              values "3.10", "3.11"
           }
         }
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import sys
 
-min_version, max_version = ((3, 8), "3.8"), ((3, 12), "3.12")
+min_version, max_version = ((3, 10), "3.10"), ((3, 12), "3.12")
 
 if not (min_version[0] <= sys.version_info[:2] <= max_version[0]):
     # Python 3.5 does not support f-strings


### PR DESCRIPTION
## Drop support for python 3.9

### Drop support for python 3.9
- *Category*: Other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5512

### Changes and notes
-drop support for python 3.9

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

