### PR TITLE
Generate stubs for Automated V&V Phase 1

### DIFF
--- a/src/vivarium_testing_utils/automated_validation/calculations.py
+++ b/src/vivarium_testing_utils/automated_validation/calculations.py
@@ -4,22 +4,22 @@ import pandas as pd
 def process_raw_data(
     input_data_type: str, raw_data: pd.DataFrame, measure: str
 ) -> pd.DataFrame:
-    pass
+    raise NotImplementedError
 
 
 def compute_metric(
     input_data_type: str, intermediate_data: pd.DataFrame, measure: str
 ) -> pd.Series:
-    pass
+    raise NotImplementedError
 
 
 def ratio(numerator, denominator):
-    pass
+    raise NotImplementedError
 
 
 def aggregate(data: pd.DataFrame, groupby_cols: list[str]) -> pd.DataFrame:
-    pass
+    raise NotImplementedError
 
 
 def linear_combination(coefficients: list[float], data: pd.DataFrame) -> pd.Series:
-    pass
+    raise NotImplementedError

--- a/src/vivarium_testing_utils/automated_validation/calculations.py
+++ b/src/vivarium_testing_utils/automated_validation/calculations.py
@@ -1,0 +1,25 @@
+import pandas as pd
+
+
+def process_raw_data(
+    input_data_type: str, raw_data: pd.DataFrame, measure: str
+) -> pd.DataFrame:
+    pass
+
+
+def compute_metric(
+    input_data_type: str, intermediate_data: pd.DataFrame, measure: str
+) -> pd.Series:
+    pass
+
+
+def ratio(numerator, denominator):
+    pass
+
+
+def aggregate(data: pd.DataFrame, groupby_cols: list[str]) -> pd.DataFrame:
+    pass
+
+
+def linear_combination(coefficients: list[float], data: pd.DataFrame) -> pd.Series:
+    pass

--- a/src/vivarium_testing_utils/automated_validation/comparison.py
+++ b/src/vivarium_testing_utils/automated_validation/comparison.py
@@ -1,14 +1,29 @@
+import pandas as pd
+
+from vivarium_testing_utils.automated_validation.calculations import compute_metric
+
+
 class Comparison:
     def __init__(
-        self, measure_key: str, test_source: str, ref_source: str, stratifications: list[str]
+        self,
+        measure_key: str,
+        test_data: pd.DataFrame,
+        reference_data: pd.DataFrame,
+        stratifications: list[str] = [],
     ):
+        self.measure = measure_key
+        self.test_data = test_data
+        self.reference_data = reference_data
+        self.computed_comparison = compute_metric(
+            self.test_data, self.reference_data, self.measure
+        )
+        # you need to marginalize out the non-stratified columns as well
+
+    def verify(self, stratifications: list[str]):
         pass
 
-    def verify():
+    def summarize(self, stratifications: list[str]):
         pass
 
-    def summarize():
-        pass
-
-    def heads():
+    def heads(self, stratifications: list[str]):
         pass

--- a/src/vivarium_testing_utils/automated_validation/comparison.py
+++ b/src/vivarium_testing_utils/automated_validation/comparison.py
@@ -20,10 +20,10 @@ class Comparison:
         # you need to marginalize out the non-stratified columns as well
 
     def verify(self, stratifications: list[str]):
-        pass
+        raise NotImplementedError
 
     def summarize(self, stratifications: list[str]):
-        pass
+        raise NotImplementedError
 
     def heads(self, stratifications: list[str]):
-        pass
+        raise NotImplementedError

--- a/src/vivarium_testing_utils/automated_validation/comparison.py
+++ b/src/vivarium_testing_utils/automated_validation/comparison.py
@@ -1,0 +1,14 @@
+class Comparison:
+    def __init__(
+        self, measure_key: str, test_source: str, ref_source: str, stratifications: list[str]
+    ):
+        pass
+
+    def verify():
+        pass
+
+    def summarize():
+        pass
+
+    def heads():
+        pass

--- a/src/vivarium_testing_utils/automated_validation/data_loader.py
+++ b/src/vivarium_testing_utils/automated_validation/data_loader.py
@@ -3,7 +3,6 @@ from layered_config_tree import LayeredConfigTree
 
 
 class DataLoader:
-
     def __init__(self, results_dir: str, cache_size_mb: int = 1000):
         self.results_dir = results_dir
         self.cache_size_mb = cache_size_mb

--- a/src/vivarium_testing_utils/automated_validation/data_loader.py
+++ b/src/vivarium_testing_utils/automated_validation/data_loader.py
@@ -11,22 +11,22 @@ class DataLoader:
         self.artifact = None  # Just stubbing this out for now
 
     def load_data(self, dataset_key: str, data_type: str) -> None:
-        pass
+        raise NotImplementedError
 
     def get_dataset(self, dataset_key: str, data_type: str) -> pd.DataFrame:
-        pass
+        raise NotImplementedError
 
     def sim_outputs(self) -> list[str]:
-        pass
+        raise NotImplementedError
 
     def artifact_keys(self) -> list[str]:
-        pass
+        raise NotImplementedError
 
     def load_from_sim(self, dataset_key: str) -> pd.DataFrame:
-        pass
+        raise NotImplementedError
 
     def load_from_artifact(self, dataset_key: str) -> pd.DataFrame:
-        pass
+        raise NotImplementedError
 
     def load_from_gbd(self, dataset_key: str) -> pd.DataFrame:
-        pass
+        raise NotImplementedError

--- a/src/vivarium_testing_utils/automated_validation/data_loader.py
+++ b/src/vivarium_testing_utils/automated_validation/data_loader.py
@@ -1,0 +1,33 @@
+import pandas as pd
+from layered_config_tree import LayeredConfigTree
+
+
+class DataLoader:
+
+    def __init__(self, results_dir: str, cache_size_mb: int = 1000):
+        self.results_dir = results_dir
+        self.cache_size_mb = cache_size_mb
+        self.raw_datasets = LayeredConfigTree()
+        self.metadata = LayeredConfigTree()
+        self.artifact = None  # Just stubbing this out for now
+
+    def load_data(dataset_key: str) -> None:
+        pass
+
+    def get_dataset(dataset_key: str) -> pd.DataFrame:
+        pass
+
+    def sim_outputs():
+        pass
+
+    def artifact_keys():
+        pass
+
+    def load_from_sim():
+        pass
+
+    def load_from_artifact():
+        pass
+
+    def load_from_gbd():
+        pass

--- a/src/vivarium_testing_utils/automated_validation/data_loader.py
+++ b/src/vivarium_testing_utils/automated_validation/data_loader.py
@@ -10,23 +10,23 @@ class DataLoader:
         self.metadata = LayeredConfigTree()
         self.artifact = None  # Just stubbing this out for now
 
-    def load_data(dataset_key: str) -> None:
+    def load_data(self, dataset_key: str, data_type: str) -> None:
         pass
 
-    def get_dataset(dataset_key: str) -> pd.DataFrame:
+    def get_dataset(self, dataset_key: str, data_type: str) -> pd.DataFrame:
         pass
 
-    def sim_outputs():
+    def sim_outputs(self) -> list[str]:
         pass
 
-    def artifact_keys():
+    def artifact_keys(self) -> list[str]:
         pass
 
-    def load_from_sim():
+    def load_from_sim(self, dataset_key: str) -> pd.DataFrame:
         pass
 
-    def load_from_artifact():
+    def load_from_artifact(self, dataset_key: str) -> pd.DataFrame:
         pass
 
-    def load_from_gbd():
+    def load_from_gbd(self, dataset_key: str) -> pd.DataFrame:
         pass

--- a/src/vivarium_testing_utils/automated_validation/interface.py
+++ b/src/vivarium_testing_utils/automated_validation/interface.py
@@ -13,10 +13,10 @@ class ValidationContext:
         self.data_loader = DataLoader(results_dir)
         self.comparisons = LayeredConfigTree()
 
-    def sim_outputs(self):
+    def get_sim_outputs(self):
         return self.data_loader.sim_outputs()
 
-    def artifact_keys(self):
+    def get_artifact_keys(self):
         return self.data_loader.artifact_keys()
 
     def add_comparison(
@@ -35,14 +35,14 @@ class ValidationContext:
         return plot_utils.plot_comparison(self.comparisons[comparison_key], type, kwargs)
 
     def generate_comparisons(self):
-        pass
+        raise NotImplementedError
 
     def verify_all(self):
         for comparison in self.comparisons.values():
             comparison.verify()
 
     def plot_all(self):
-        pass
+        raise NotImplementedError
 
     def get_results(self, verbose: bool = False):
-        pass
+        raise NotImplementedError

--- a/src/vivarium_testing_utils/automated_validation/interface.py
+++ b/src/vivarium_testing_utils/automated_validation/interface.py
@@ -1,13 +1,14 @@
 from pathlib import Path
-from vivarium_testing_utils.automated_validation.data_loader import DataLoader
-from layered_config_tree import LayeredConfigTree
+
 import pandas as pd
-from vivarium_testing_utils.automated_validation.comparison import Comparison
+from layered_config_tree import LayeredConfigTree
+
 from vivarium_testing_utils.automated_validation import plot_utils
+from vivarium_testing_utils.automated_validation.comparison import Comparison
+from vivarium_testing_utils.automated_validation.data_loader import DataLoader
 
 
 class ValidationContext:
-
     def __init__(self, results_dir: str | Path, age_groups: pd.DataFrame | None):
         self.data_loader = DataLoader(results_dir)
         self.comparisons = LayeredConfigTree()

--- a/src/vivarium_testing_utils/automated_validation/interface.py
+++ b/src/vivarium_testing_utils/automated_validation/interface.py
@@ -31,7 +31,7 @@ class ValidationContext:
     def verify(self, comparison_key: str, stratifications: list[str] = []):
         self.comparisons[comparison_key].verify(stratifications)
 
-    def plot_comparison(self, comparison_key: str, type: str, kwargs):
+    def plot_comparison(self, comparison_key: str, type: str, **kwargs):
         return plot_utils.plot_comparison(self.comparisons[comparison_key], type, kwargs)
 
     def generate_comparisons(self):

--- a/src/vivarium_testing_utils/automated_validation/interface.py
+++ b/src/vivarium_testing_utils/automated_validation/interface.py
@@ -22,12 +22,14 @@ class ValidationContext:
     def add_comparison(
         self, measure_key: str, test_source: str, ref_source: str, stratifications: list[str]
     ) -> None:
+        test_data = self.data_loader.get_dataset(measure_key, test_source)
+        ref_data = self.data_loader.get_dataset(measure_key, ref_source)
         self.comparisons.update(
-            [measure_key], Comparison(measure_key, test_source, ref_source, stratifications)
+            [measure_key], Comparison(measure_key, test_data, ref_data, stratifications)
         )
 
-    def verify_comparison(self, comparison_key: str):
-        self.comparisons[comparison_key].verify()
+    def verify(self, comparison_key: str, stratifications: list[str] = []):
+        self.comparisons[comparison_key].verify(stratifications)
 
     def plot_comparison(self, comparison_key: str, type: str, kwargs):
         return plot_utils.plot_comparison(self.comparisons[comparison_key], type, kwargs)
@@ -36,10 +38,11 @@ class ValidationContext:
         pass
 
     def verify_all(self):
-        pass
+        for comparison in self.comparisons.values():
+            comparison.verify()
 
     def plot_all(self):
         pass
 
-    def get_results(self):
+    def get_results(self, verbose: bool = False):
         pass

--- a/src/vivarium_testing_utils/automated_validation/interface.py
+++ b/src/vivarium_testing_utils/automated_validation/interface.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from vivarium_testing_utils.automated_validation.data_loader import DataLoader
+from layered_config_tree import LayeredConfigTree
+import pandas as pd
+from vivarium_testing_utils.automated_validation.comparison import Comparison
+from vivarium_testing_utils.automated_validation import plot_utils
+
+
+class ValidationContext:
+
+    def __init__(self, results_dir: str | Path, age_groups: pd.DataFrame | None):
+        self.data_loader = DataLoader(results_dir)
+        self.comparisons = LayeredConfigTree()
+
+    def sim_outputs(self):
+        return self.data_loader.sim_outputs()
+
+    def artifact_keys(self):
+        return self.data_loader.artifact_keys()
+
+    def add_comparison(
+        self, measure_key: str, test_source: str, ref_source: str, stratifications: list[str]
+    ) -> None:
+        self.comparisons.update(
+            [measure_key], Comparison(measure_key, test_source, ref_source, stratifications)
+        )
+
+    def verify_comparison(self, comparison_key: str):
+        self.comparisons[comparison_key].verify()
+
+    def plot_comparison(self, comparison_key: str, type: str, kwargs):
+        return plot_utils.plot_comparison(self.comparisons[comparison_key], type, kwargs)
+
+    def generate_comparisons(self):
+        pass
+
+    def verify_all(self):
+        pass
+
+    def plot_all(self):
+        pass
+
+    def get_results(self):
+        pass

--- a/src/vivarium_testing_utils/automated_validation/plot_utils.py
+++ b/src/vivarium_testing_utils/automated_validation/plot_utils.py
@@ -1,5 +1,6 @@
-from vivarium_testing_utils.automated_validation.comparison import Comparison
 import pandas as pd
+
+from vivarium_testing_utils.automated_validation.comparison import Comparison
 
 
 def plot_comparison(comparison: Comparison, type: str, kwargs):

--- a/src/vivarium_testing_utils/automated_validation/plot_utils.py
+++ b/src/vivarium_testing_utils/automated_validation/plot_utils.py
@@ -1,0 +1,30 @@
+from vivarium_testing_utils.automated_validation.comparison import Comparison
+import pandas as pd
+
+
+def plot_comparison(comparison: Comparison, type: str, kwargs):
+    pass
+
+
+def plot_data(dataset: pd.DataFrame, type: str, kwargs):
+    pass
+
+
+def line_plot(comparison: Comparison, x_axis: str, stratifications: list[str]):
+    pass
+
+
+def bar_plot(comparison: Comparison, x_axis: str, stratifications: list[str]):
+    pass
+
+
+def box_plot(comparison: Comparison, cat: str, stratifications: list[str]):
+    pass
+
+
+def heatmap(comparison: Comparison, row: str, col: str):
+    pass
+
+
+def save_plot(fig, name, format):
+    pass

--- a/src/vivarium_testing_utils/automated_validation/plot_utils.py
+++ b/src/vivarium_testing_utils/automated_validation/plot_utils.py
@@ -4,28 +4,28 @@ from vivarium_testing_utils.automated_validation.comparison import Comparison
 
 
 def plot_comparison(comparison: Comparison, type: str, kwargs):
-    pass
+    raise NotImplementedError
 
 
 def plot_data(dataset: pd.DataFrame, type: str, kwargs):
-    pass
+    raise NotImplementedError
 
 
 def line_plot(comparison: Comparison, x_axis: str, stratifications: list[str]):
-    pass
+    raise NotImplementedError
 
 
 def bar_plot(comparison: Comparison, x_axis: str, stratifications: list[str]):
-    pass
+    raise NotImplementedError
 
 
 def box_plot(comparison: Comparison, cat: str, stratifications: list[str]):
-    pass
+    raise NotImplementedError
 
 
 def heatmap(comparison: Comparison, row: str, col: str):
-    pass
+    raise NotImplementedError
 
 
 def save_plot(fig, name, format):
-    pass
+    raise NotImplementedError


### PR DESCRIPTION
## Generate stubs for Automated V&V Phase 1
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5916

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
I stubbed out the classes from phase 1 in accordance with the design document
https://hub.ihme.washington.edu/spaces/SSE/pages/381354690/Phase+1+Standard+Metric+Comparisons

I left a few signatures blank, as well as the docstrings; I didn't want to fill out too much too quickly as things are subject to change.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

