### PR TITLE
Refactor pandera to use SchemaModel decorators

### DIFF
--- a/src/vivarium_testing_utils/automated_validation/comparison.py
+++ b/src/vivarium_testing_utils/automated_validation/comparison.py
@@ -37,7 +37,6 @@ class Comparison(ABC):
 
 
 class FuzzyComparison:
-
     def __init__(
         self,
         measure: RatioMeasure,

--- a/src/vivarium_testing_utils/automated_validation/comparison.py
+++ b/src/vivarium_testing_utils/automated_validation/comparison.py
@@ -38,11 +38,12 @@ class Comparison(ABC):
 
 
 class FuzzyComparison:
+
     def __init__(
         self,
         measure: RatioMeasure,
-        test_data: DataFrame[RatioData],
-        reference_data: DataFrame[SingleNumericColumn],
+        test_data: pd.DataFrame,
+        reference_data: pd.DataFrame,
         stratifications: list[str] = [],
     ):
         self.measure = measure

--- a/src/vivarium_testing_utils/automated_validation/comparison.py
+++ b/src/vivarium_testing_utils/automated_validation/comparison.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 
 import pandas as pd
-from pandera.typing import DataFrame
 
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
     RatioData,

--- a/src/vivarium_testing_utils/automated_validation/data_loader.py
+++ b/src/vivarium_testing_utils/automated_validation/data_loader.py
@@ -14,6 +14,7 @@ from vivarium_testing_utils.automated_validation.data_transformation.calculation
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
     SimOutputData,
     SingleNumericColumn,
+    check_io,
 )
 
 
@@ -75,7 +76,7 @@ class DataLoader:
             raise ValueError(f"Dataset {dataset_key} already exists in the cache.")
         self._raw_datasets.update({source: {dataset_key: data.copy()}})
 
-    @pa.check_io(out=SimOutputData.to_schema())
+    @check_io(out=SimOutputData)
     def _load_from_sim(self, dataset_key: str) -> pd.DataFrame:
         """Load the data from the simulation output directory and set the non-value columns as indices."""
         sim_data = pd.read_parquet(self._results_dir / f"{dataset_key}.parquet")
@@ -108,7 +109,7 @@ class DataLoader:
         ]["artifact_path"]
         return Artifact(artifact_path)
 
-    @pa.check_io(out=SingleNumericColumn.to_schema())
+    @check_io(out=SingleNumericColumn)
     def _load_from_artifact(self, dataset_key: str) -> pd.DataFrame:
         data = self._artifact.load(dataset_key)
         self._artifact.clear_cache()

--- a/src/vivarium_testing_utils/automated_validation/data_loader.py
+++ b/src/vivarium_testing_utils/automated_validation/data_loader.py
@@ -14,8 +14,8 @@ from vivarium_testing_utils.automated_validation.data_transformation.calculation
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
     SimOutputData,
     SingleNumericColumn,
-    check_io,
 )
+from vivarium_testing_utils.automated_validation.data_transformation.utils import check_io
 
 
 class DataSource(Enum):

--- a/src/vivarium_testing_utils/automated_validation/data_loader.py
+++ b/src/vivarium_testing_utils/automated_validation/data_loader.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import pandas as pd
 import pandera as pa
 import yaml
-from pandera.typing import DataFrame
 from vivarium import Artifact
 
 from vivarium_testing_utils.automated_validation.data_transformation.calculations import (
@@ -76,8 +75,8 @@ class DataLoader:
             raise ValueError(f"Dataset {dataset_key} already exists in the cache.")
         self._raw_datasets.update({source: {dataset_key: data.copy()}})
 
-    @pa.check_types
-    def _load_from_sim(self, dataset_key: str) -> DataFrame[SimOutputData]:
+    @pa.check_io(out=SimOutputData.to_schema())
+    def _load_from_sim(self, dataset_key: str) -> pd.DataFrame:
         """Load the data from the simulation output directory and set the non-value columns as indices."""
         sim_data = pd.read_parquet(self._results_dir / f"{dataset_key}.parquet")
         if "value" not in sim_data.columns:
@@ -109,8 +108,8 @@ class DataLoader:
         ]["artifact_path"]
         return Artifact(artifact_path)
 
-    @pa.check_types
-    def _load_from_artifact(self, dataset_key: str) -> DataFrame[SingleNumericColumn]:
+    @pa.check_io(out=SingleNumericColumn.to_schema())
+    def _load_from_artifact(self, dataset_key: str) -> pd.DataFrame:
         data = self._artifact.load(dataset_key)
         self._artifact.clear_cache()
         return clean_artifact_data(dataset_key, data)

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
@@ -2,10 +2,8 @@ from typing import TypeVar
 
 import pandas as pd
 import pandera as pa
-from pandera.typing import DataFrame
 
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
-    RawArtifactData,
     SingleNumericColumn,
 )
 
@@ -48,10 +46,10 @@ def filter_data(data: DataSet, filter_cols: dict[str, list]) -> DataSet:
     return data
 
 
-def ratio(data: pd.DataFrame, numerator: str, denominator: str) -> pd.Series:
+def ratio(data: pd.DataFrame, numerator: str, denominator: str) -> pd.DataFrame:
     """Return a series of the ratio of two columns in a DataFrame,
     where the columns are specified by their names."""
-    return data[numerator] / data[denominator]
+    return (data[numerator] / data[denominator]).to_frame(name="value")
 
 
 def aggregate_sum(data: DataSet, groupby_cols: list[str]) -> DataSet:
@@ -73,16 +71,16 @@ def marginalize(data: DataSet, marginalize_cols: list[str]) -> DataSet:
 
 def linear_combination(
     data: pd.DataFrame, coeff_a: float, col_a: str, coeff_b: float, col_b: str
-) -> pd.Series:
+) -> pd.DataFrame:
     """Return a series that is the linear combination of two columns in a DataFrame."""
-    return (data[col_a] * coeff_a) + (data[col_b] * coeff_b)
+    return ((data[col_a] * coeff_a) + (data[col_b] * coeff_b)).to_frame(name="value")
 
 
-@pa.check_types
+@pa.check_io(out=SingleNumericColumn.to_schema())
 def clean_artifact_data(
     dataset_key: str,
-    data: RawArtifactData,
-) -> DataFrame[SingleNumericColumn]:
+    data: pd.DataFrame,
+) -> pd.DataFrame:
     """Clean the artifact data by dropping unnecessary columns and renaming the value column."""
     # Drop unnecessary columns
     # if data has value columns of format draw_1, draw_2, etc., drop the draw_ prefix

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
@@ -5,6 +5,7 @@ import pandera as pa
 
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
     SingleNumericColumn,
+    check_io,
 )
 
 DataSet = TypeVar("DataSet", pd.DataFrame, pd.Series)
@@ -76,7 +77,7 @@ def linear_combination(
     return ((data[col_a] * coeff_a) + (data[col_b] * coeff_b)).to_frame(name="value")
 
 
-@pa.check_io(out=SingleNumericColumn.to_schema())
+@check_io(out=SingleNumericColumn)
 def clean_artifact_data(
     dataset_key: str,
     data: pd.DataFrame,

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
@@ -4,8 +4,8 @@ import pandas as pd
 import pandera as pa
 
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
-    SingleNumericColumn,
     DrawData,
+    SingleNumericColumn,
     check_io,
     series_to_dataframe,
 )

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
@@ -6,6 +6,8 @@ import pandera as pa
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
     DrawData,
     SingleNumericColumn,
+)
+from vivarium_testing_utils.automated_validation.data_transformation.utils import (
     check_io,
     series_to_dataframe,
 )

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
@@ -6,6 +6,7 @@ import pandera as pa
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
     SingleNumericColumn,
     check_io,
+    series_to_dataframe,
 )
 
 DataSet = TypeVar("DataSet", pd.DataFrame, pd.Series)
@@ -50,7 +51,7 @@ def filter_data(data: DataSet, filter_cols: dict[str, list]) -> DataSet:
 def ratio(data: pd.DataFrame, numerator: str, denominator: str) -> pd.DataFrame:
     """Return a series of the ratio of two columns in a DataFrame,
     where the columns are specified by their names."""
-    return (data[numerator] / data[denominator]).to_frame(name="value")
+    return series_to_dataframe(data[numerator] / data[denominator])
 
 
 def aggregate_sum(data: DataSet, groupby_cols: list[str]) -> DataSet:
@@ -74,7 +75,7 @@ def linear_combination(
     data: pd.DataFrame, coeff_a: float, col_a: str, coeff_b: float, col_b: str
 ) -> pd.DataFrame:
     """Return a series that is the linear combination of two columns in a DataFrame."""
-    return ((data[col_a] * coeff_a) + (data[col_b] * coeff_b)).to_frame(name="value")
+    return series_to_dataframe((data[col_a] * coeff_a) + (data[col_b] * coeff_b))
 
 
 @check_io(out=SingleNumericColumn)

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
@@ -87,9 +87,6 @@ def clean_artifact_data(
     data: pd.DataFrame,
 ) -> pd.DataFrame:
     """Clean the artifact data by dropping unnecessary columns and renaming the value column."""
-    # Drop unnecessary columns
-    # if data has value columns of format draw_1, draw_2, etc., drop the draw_ prefix
-    # and melt the data into long format
     if data.columns.str.startswith(DRAW_PREFIX).all():
         data = _clean_artifact_draws(data)
     elif "value" not in data.columns:

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+import pandas as pd
 import pandera as pa
 from pandera.typing import Index
-import pandas as pd
+
 
 class SingleNumericColumn(pa.DataFrameModel):
     """We restrict many intermediate dataframes to a single numeric column.

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pandas as pd
 import pandera as pa
 from pandera.typing import Index

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
@@ -1,5 +1,5 @@
 import pandera as pa
-from pandera.typing import DataFrame, Index
+from pandera.typing import Index
 import pandas as pd
 
 class SingleNumericColumn(pa.DataFrameModel):

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
@@ -58,35 +58,3 @@ class RatioData(pa.DataFrameModel):
         # and both are numeric
         numeric_columns = df.select_dtypes(include=["number"]).columns
         return len(numeric_columns) == df.shape[1] == 2
-
-
-def check_io(**model_dict):
-    """
-    A wrapper for pa.check_io that automatically converts SchemaModels to schemas.
-
-    Args:
-        **model_dict: Keyword arguments where keys are parameter names and values
-                     are SchemaModel classes or schema objects.
-
-    Returns:
-        A decorator function that wraps the target function with pa.check_io.
-    """
-    # Convert any SchemaModel classes to schemas
-    schema_dict = {}
-    for key, value in model_dict.items():
-        # Check if it's a SchemaModel class (not instance) and has to_schema method
-        if hasattr(value, "to_schema") and callable(value.to_schema):
-            schema_dict[key] = value.to_schema()
-        else:
-            # If it's already a schema or something else, use it as is
-            schema_dict[key] = value
-
-    # Return the decorator using pa.check_io with the converted schemas
-    return pa.check_io(**schema_dict)
-
-
-# TODO: Remove this function and references when we can support Series schemas
-# more easily
-def series_to_dataframe(series: pd.Series[float]) -> pd.DataFrame:
-    """Convert a Series to a DataFrame with the Series values as a single column."""
-    return series.to_frame(name="value")

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
@@ -1,6 +1,6 @@
 import pandera as pa
 from pandera.typing import DataFrame, Index
-
+import pandas as pd
 
 class SingleNumericColumn(pa.DataFrameModel):
     """We restrict many intermediate dataframes to a single numeric column.
@@ -43,9 +43,6 @@ class DrawData(pa.DataFrameModel):
         strict = True
 
 
-RawArtifactData = DataFrame[SingleNumericColumn] | DataFrame[DrawData]
-
-
 class RatioData(pa.DataFrameModel):
     """Ratio data is a dataframe with two numeric columns.
 
@@ -53,7 +50,7 @@ class RatioData(pa.DataFrameModel):
 
     # Custom Checks
     @pa.dataframe_check
-    def check_two_numeric_columns(cls, df: DataFrame) -> bool:
+    def check_two_numeric_columns(cls, df: pd.DataFrame) -> bool:
         # Check that there are exactly two columns in the DataFrame,
         # and both are numeric
         numeric_columns = df.select_dtypes(include=["number"]).columns

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pandas as pd
 import pandera as pa
 from pandera.typing import Index

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
@@ -80,3 +80,10 @@ def check_io(**model_dict):
 
     # Return the decorator using pa.check_io with the converted schemas
     return pa.check_io(**schema_dict)
+
+
+# TODO: Remove this function and references when we can support Series schemas
+# more easily
+def series_to_dataframe(series: pd.Series[float]) -> pd.DataFrame:
+    """Convert a Series to a DataFrame with the Series values as a single column."""
+    return series.to_frame(name="value")

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
@@ -56,9 +56,6 @@ class RatioData(pa.DataFrameModel):
         numeric_columns = df.select_dtypes(include=["number"]).columns
         return len(numeric_columns) == df.shape[1] == 2
 
-import functools
-import pandera as pa
-
 
 def check_io(**model_dict):
     """

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
@@ -55,3 +55,31 @@ class RatioData(pa.DataFrameModel):
         # and both are numeric
         numeric_columns = df.select_dtypes(include=["number"]).columns
         return len(numeric_columns) == df.shape[1] == 2
+
+import functools
+import pandera as pa
+
+
+def check_io(**model_dict):
+    """
+    A wrapper for pa.check_io that automatically converts SchemaModels to schemas.
+
+    Args:
+        **model_dict: Keyword arguments where keys are parameter names and values
+                     are SchemaModel classes or schema objects.
+
+    Returns:
+        A decorator function that wraps the target function with pa.check_io.
+    """
+    # Convert any SchemaModel classes to schemas
+    schema_dict = {}
+    for key, value in model_dict.items():
+        # Check if it's a SchemaModel class (not instance) and has to_schema method
+        if hasattr(value, "to_schema") and callable(value.to_schema):
+            schema_dict[key] = value.to_schema()
+        else:
+            # If it's already a schema or something else, use it as is
+            schema_dict[key] = value
+
+    # Return the decorator using pa.check_io with the converted schemas
+    return pa.check_io(**schema_dict)

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/measures.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/measures.py
@@ -12,13 +12,13 @@ from vivarium_testing_utils.automated_validation.data_transformation.data_schema
     RatioData,
     SimOutputData,
     SingleNumericColumn,
-    check_io,
 )
 from vivarium_testing_utils.automated_validation.data_transformation.formatting import (
     PersonTime,
     SimDataFormatter,
     TransitionCounts,
 )
+from vivarium_testing_utils.automated_validation.data_transformation.utils import check_io
 
 
 class Measure(ABC):

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/measures.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/measures.py
@@ -12,6 +12,7 @@ from vivarium_testing_utils.automated_validation.data_transformation.data_schema
     RatioData,
     SimOutputData,
     SingleNumericColumn,
+    check_io,
 )
 from vivarium_testing_utils.automated_validation.data_transformation.formatting import (
     PersonTime,
@@ -37,7 +38,7 @@ class Measure(ABC):
         """Process raw simulation data into a format suitable for calculations."""
         pass
 
-    @pa.check_io(out=SingleNumericColumn.to_schema())
+    @check_io(out=SingleNumericColumn)
     def get_measure_data(self, source: DataSource, *args, **kwargs) -> pd.DataFrame:
         """Process data from the specified source into a format suitable for calculations."""
         if source == DataSource.SIM:
@@ -88,13 +89,11 @@ class RatioMeasure(Measure, ABC):
         """Process raw simulation data into a format suitable for calculations."""
         pass
 
-    @pa.check_io(
-        artifact_data=SingleNumericColumn.to_schema(), out=SingleNumericColumn.to_schema()
-    )
+    @check_io(artifact_data=SingleNumericColumn, out=SingleNumericColumn)
     def get_measure_data_from_artifact(self, artifact_data: pd.DataFrame) -> pd.DataFrame:
         return artifact_data
 
-    @pa.check_io(ratio_data=RatioData.to_schema(), out=SingleNumericColumn.to_schema())
+    @check_io(ratio_data=RatioData, out=SingleNumericColumn)
     def get_measure_data_from_ratio(self, ratio_data: pd.DataFrame) -> pd.DataFrame:
         """Compute final measure data from split data."""
         return ratio(
@@ -103,15 +102,15 @@ class RatioMeasure(Measure, ABC):
             denominator=self.denominator.new_value_column_name,
         )
 
-    @pa.check_io(out=SingleNumericColumn.to_schema())
+    @check_io(out=SingleNumericColumn)
     def get_measure_data_from_sim(self, *args, **kwargs) -> pd.DataFrame:
         """Process raw simulation data into a format suitable for calculations."""
         return self.get_measure_data_from_ratio(self.get_ratio_data_from_sim(*args, **kwargs))
 
-    @pa.check_io(
-        numerator_data=SimOutputData.to_schema(),
-        denominator_data=SimOutputData.to_schema(),
-        out=RatioData.to_schema(),
+    @check_io(
+        numerator_data=SimOutputData,
+        denominator_data=SimOutputData,
+        out=RatioData,
     )
     def get_ratio_data_from_sim(
         self,

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/utils.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pandas as pd
 import pandera as pa
 

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/utils.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/utils.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import pandera as pa
+
+
+def check_io(**model_dict):
+    """
+    A wrapper for pa.check_io that automatically converts SchemaModels to schemas.
+
+    Args:
+        **model_dict: Keyword arguments where keys are parameter names and values
+                     are SchemaModel classes or schema objects.
+
+    Returns:
+        A decorator function that wraps the target function with pa.check_io.
+    """
+    # Convert any SchemaModel classes to schemas
+    schema_dict = {}
+    for key, value in model_dict.items():
+        # Check if it's a SchemaModel class (not instance) and has to_schema method
+        if hasattr(value, "to_schema") and callable(value.to_schema):
+            schema_dict[key] = value.to_schema()
+        else:
+            # If it's already a schema or something else, use it as is
+            schema_dict[key] = value
+
+    # Return the decorator using pa.check_io with the converted schemas
+    return pa.check_io(**schema_dict)
+
+
+# TODO: Remove this function and references when we can support Series schemas
+# more easily
+def series_to_dataframe(series: pd.Series[float]) -> pd.DataFrame:
+    """Convert a Series to a DataFrame with the Series values as a single column."""
+    return series.to_frame(name="value")

--- a/tests/automated_validation/conftest.py
+++ b/tests/automated_validation/conftest.py
@@ -5,9 +5,8 @@ import pandera as pa
 import pytest
 
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
-    DrawData,
-    SimOutputData,
     SingleNumericColumn,
+    check_io,
 )
 
 
@@ -16,7 +15,7 @@ def sim_result_dir() -> Path:
     return Path(__file__).parent / "data/sim_outputs"
 
 
-@pa.check_io(out=SingleNumericColumn.to_schema())
+@check_io(out=SingleNumericColumn)
 @pytest.fixture
 def transition_count_data() -> pd.DataFrame:
     return pd.DataFrame(
@@ -59,7 +58,7 @@ def transition_count_data() -> pd.DataFrame:
     )
 
 
-@pa.check_io(out=SingleNumericColumn.to_schema())
+@check_io(out=SingleNumericColumn)
 @pytest.fixture
 def person_time_data() -> pd.DataFrame:
     return pd.DataFrame(
@@ -95,7 +94,7 @@ def raw_artifact_disease_incidence() -> pd.DataFrame:
     )
 
 
-@pa.check_io(out=SingleNumericColumn.to_schema())
+@check_io(out=SingleNumericColumn)
 @pytest.fixture
 def artifact_disease_incidence() -> pd.DataFrame:
     return pd.DataFrame(

--- a/tests/automated_validation/conftest.py
+++ b/tests/automated_validation/conftest.py
@@ -6,8 +6,8 @@ import pytest
 
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
     SingleNumericColumn,
-    check_io,
 )
+from vivarium_testing_utils.automated_validation.data_transformation.utils import check_io
 
 
 @pytest.fixture

--- a/tests/automated_validation/conftest.py
+++ b/tests/automated_validation/conftest.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import pandas as pd
 import pandera as pa
 import pytest
-from pandera.typing import DataFrame
 
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
     DrawData,
@@ -17,9 +16,9 @@ def sim_result_dir() -> Path:
     return Path(__file__).parent / "data/sim_outputs"
 
 
-@pa.check_types
+@pa.check_io(out=SingleNumericColumn.to_schema())
 @pytest.fixture
-def transition_count_data() -> DataFrame[SimOutputData]:
+def transition_count_data() -> pd.DataFrame:
     return pd.DataFrame(
         {
             "value": [3.0, 5.0, 7.0, 13.0],
@@ -60,9 +59,9 @@ def transition_count_data() -> DataFrame[SimOutputData]:
     )
 
 
-@pa.check_types
+@pa.check_io(out=SingleNumericColumn.to_schema())
 @pytest.fixture
-def person_time_data() -> DataFrame[SimOutputData]:
+def person_time_data() -> pd.DataFrame:
     return pd.DataFrame(
         {
             "value": [17.0, 23.0, 29.0, 37.0],
@@ -80,7 +79,7 @@ def person_time_data() -> DataFrame[SimOutputData]:
 
 
 @pytest.fixture
-def raw_artifact_disease_incidence() -> DataFrame[DrawData]:
+def raw_artifact_disease_incidence() -> pd.DataFrame:
     return pd.DataFrame(
         {
             "draw_0": [0.17, 0.13],
@@ -96,9 +95,9 @@ def raw_artifact_disease_incidence() -> DataFrame[DrawData]:
     )
 
 
-@pa.check_types
+@pa.check_io(out=SingleNumericColumn.to_schema())
 @pytest.fixture
-def artifact_disease_incidence() -> DataFrame[SingleNumericColumn]:
+def artifact_disease_incidence() -> pd.DataFrame:
     return pd.DataFrame(
         {
             "value": [

--- a/tests/automated_validation/data_transformation/test_calculations.py
+++ b/tests/automated_validation/data_transformation/test_calculations.py
@@ -31,10 +31,10 @@ def intermediate_data() -> pd.DataFrame:
 def test_ratio(intermediate_data: pd.DataFrame) -> None:
     """Test taking ratio of two columns in a multi-indexed DataFrame"""
     assert ratio(intermediate_data, "a", "b").equals(
-        pd.Series([1 / 4, 2 / 5, 3 / 6, 4 / 7], index=intermediate_data.index)
+        pd.DataFrame({"value": [1 / 4, 2 / 5, 3 / 6, 4 / 7]}, index=intermediate_data.index)
     )
     assert ratio(intermediate_data, "a", "c").equals(
-        pd.Series([1, 2, float("inf"), 4], index=intermediate_data.index)
+        pd.DataFrame({"value": [1, 2, float("inf"), 4]}, index=intermediate_data.index)
     )
     # test non-existent column
     with pytest.raises(KeyError):
@@ -72,10 +72,10 @@ def test_aggregate(intermediate_data: pd.DataFrame) -> None:
 def test_linear_combination(intermediate_data: pd.DataFrame) -> None:
     """Test linear combination of two columns in a multi-indexed DataFrame"""
     assert linear_combination(intermediate_data, 1, "a", 1, "b").equals(
-        pd.Series([5, 7, 9, 11], index=intermediate_data.index)
+        pd.DataFrame({"value": [5, 7, 9, 11]}, index=intermediate_data.index)
     )
     assert linear_combination(intermediate_data, 2, "a", -1, "b").equals(
-        pd.Series([-2, -1, 0, 1], index=intermediate_data.index)
+        pd.DataFrame({"value": [-2, -1, 0, 1]}, index=intermediate_data.index)
     )
     # test non-existent column
     with pytest.raises(KeyError):

--- a/tests/automated_validation/data_transformation/test_measures.py
+++ b/tests/automated_validation/data_transformation/test_measures.py
@@ -41,8 +41,8 @@ def test_incidence(
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=transition_count_data, denominator_data=person_time_data
     )
-    expected_measure_data = pd.Series(
-        [3 / 17.0, 5 / 29.0],
+    expected_measure_data = pd.DataFrame(
+        {"value": [3 / 17.0, 5 / 29.0]},
         index=pd.Index(
             ["A", "B"],
             name="stratify_column",
@@ -82,8 +82,8 @@ def test_prevalence(person_time_data: pd.DataFrame) -> None:
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=person_time_data, denominator_data=person_time_data
     )
-    expected_measure_data = pd.Series(
-        [23.0 / (17.0 + 23.0), 37.0 / (29.0 + 37.0)],
+    expected_measure_data = pd.DataFrame(
+        {"value": [23.0 / (17.0 + 23.0), 37.0 / (29.0 + 37.0)]},
         index=pd.Index(
             ["A", "B"],
             name="stratify_column",
@@ -127,8 +127,8 @@ def test_si_remission(
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=transition_count_data, denominator_data=person_time_data
     )
-    expected_measure_data = pd.Series(
-        [7 / 23.0, 13 / 37.0],
+    expected_measure_data = pd.DataFrame(
+        {"value": [7 / 23.0, 13 / 37.0]},
         index=pd.Index(
             ["A", "B"],
             name="stratify_column",


### PR DESCRIPTION
## Refactor pandera to use SchemaModel decorators 
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6006

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Use the SchemaModel form of the decorators so we can just use normal pandas typing. I've wrapped
`pa.check_io()` so that I don't have to call `.to_schema()` on every single one of the DataFrameModels.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

