### PR TITLE
Aggregate instead of check and drop during formatting

### DIFF
--- a/src/vivarium_testing_utils/automated_validation/data_transformation/formatting.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/formatting.py
@@ -16,23 +16,18 @@ class SimDataFormatter:
         self.type = type
         self.cause = cause
         self.data_key = f"{self.type}_{self.cause}"
-        self.redundant_columns = {
-            "measure": self.type,
-            "entity_type": "cause",
-            "entity": self.cause,
-        }
+        self.unused_cols = [
+            "measure",
+            "entity_type",
+            "entity",
+        ]
         self.filter_column = "sub_entity"
         self.filter_value = filter_value
         self.new_value_column_name = f"{self.filter_value}_{self.type}"
 
     def format_dataset(self, dataset: pd.DataFrame) -> pd.DataFrame:
         """Clean up redundant columns, filter for the state, and rename the value column."""
-        for column, value in self.redundant_columns.items():
-            dataset = _drop_redundant_index(
-                dataset,
-                column,
-                value,
-            )
+        dataset = marginalize(dataset, self.unused_cols)
         if self.filter_value == "total":
             dataset = marginalize(dataset, [self.filter_column])
         else:
@@ -53,17 +48,3 @@ class PersonTime(SimDataFormatter):
 
     def __init__(self, cause: str, state: str | None = None) -> None:
         super().__init__("person_time", cause, state or "total")
-
-
-def _drop_redundant_index(
-    data: pd.DataFrame, idx_column_name: str, idx_column_value: str
-) -> pd.DataFrame:
-    """Validate that a DataFrame column is singular-valued, then drop it from the index."""
-    # TODO: Make sure we handle this case appropriately when we
-    # want to automatically add many comparisons
-    if not (data.index.get_level_values(idx_column_name) == idx_column_value).all():
-        raise ValueError(
-            f"Cause {data.index.get_level_values(idx_column_name).unique()} in data does not match expected cause {idx_column_name}"
-        )
-    data = data.droplevel([idx_column_name])
-    return data

--- a/tests/automated_validation/data_transformation/test_formatting.py
+++ b/tests/automated_validation/data_transformation/test_formatting.py
@@ -1,59 +1,9 @@
 import pandas as pd
-import pytest
 
-from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
-    SimOutputData,
-)
 from vivarium_testing_utils.automated_validation.data_transformation.formatting import (
     PersonTime,
     TransitionCounts,
-    _drop_redundant_index,
 )
-
-
-def test__drop_redundant_index() -> None:
-    """Test drop_redundant_index function."""
-    # Create a mock dataset
-    dataset = pd.DataFrame(
-        {
-            "value": [10, 20, 30, 40],
-        },
-        index=pd.MultiIndex.from_tuples(
-            [
-                ("redundant_column", "heterogeneous"),
-                ("redundant_column", "values"),
-                ("redundant_column", "in_this"),
-                ("redundant_column", "column"),
-            ],
-            names=["redundant_column", "interesting_column"],
-        ),
-    )
-    expected_dataframe = pd.DataFrame(
-        {
-            "value": [10, 20, 30, 40],
-        },
-        index=pd.Index(
-            ["heterogeneous", "values", "in_this", "column"],
-            name="interesting_column",
-        ),
-    )
-    # Call the function to drop the redundant index
-    formatted_dataset = _drop_redundant_index(dataset, "redundant_column", "redundant_column")
-    assert formatted_dataset.equals(expected_dataframe)
-
-    # Test that we raise an error if the column has more than one value
-    dataset = dataset.copy()
-    dataset.index = pd.MultiIndex.from_tuples(
-        [
-            ("redundant_column", "heterogeneous"),
-            ("redundant_column", "values"),
-            ("redundant_column", "in_this"),
-            ("not_redundant!", "column"),
-        ],
-        names=["redundant_column", "interesting_column"],
-    )
-    with pytest.raises(ValueError):
-        _drop_redundant_index(dataset, "redundant_column", "redundant_column")
 
 
 def test_transition_counts(transition_count_data: pd.DataFrame) -> None:
@@ -70,11 +20,7 @@ def test_transition_counts(transition_count_data: pd.DataFrame) -> None:
         formatter.new_value_column_name
         == "susceptible_to_disease_to_disease_transition_count"
     )
-    assert formatter.redundant_columns == {
-        "measure": "transition_count",
-        "entity_type": "cause",
-        "entity": "disease",
-    }
+    assert formatter.unused_cols == ["measure", "entity_type", "entity"]
 
     expected_dataframe = pd.DataFrame(
         {
@@ -99,11 +45,7 @@ def test_person_time(person_time_data: pd.DataFrame) -> None:
     assert formatter.data_key == "person_time_disease"
     assert formatter.filter_column == "sub_entity"
     assert formatter.new_value_column_name == "disease_person_time"
-    assert formatter.redundant_columns == {
-        "measure": "person_time",
-        "entity_type": "cause",
-        "entity": "disease",
-    }
+    assert formatter.unused_cols == ["measure", "entity_type", "entity"]
 
     expected_dataframe = pd.DataFrame(
         {
@@ -127,11 +69,7 @@ def test_total_pt(person_time_data: pd.DataFrame) -> None:
     assert formatter.data_key == "person_time_disease"
     assert formatter.filter_column == "sub_entity"
     assert formatter.new_value_column_name == "total_person_time"
-    assert formatter.redundant_columns == {
-        "measure": "person_time",
-        "entity_type": "cause",
-        "entity": "disease",
-    }
+    assert formatter.unused_cols == ["measure", "entity_type", "entity"]
 
     expected_dataframe = pd.DataFrame(
         {


### PR DESCRIPTION
## Aggregate instead of check and drop during formatting
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5993

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Previously, we were dropping "redundant" index levels by checking that they had exactly one value and then dropping it.
I've come to think this is kind of overkill, and we can just aggregate over them. This crops up in `deaths` sim files, when `entity_type` might be `cause` or `risk_attributable_disease`, but I don't think we really care about the distinction, since we know the particular cause/disease type from `"entity" and "sub_entity"`, and the artifact just labels these all as causes anyway.

If the distinction in a particular index level is important, we should know ahead of time and be able to adjust the formatter appropriately. 
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

