### PR TITLE
Refactor ratiodata to just two dataframes

### DIFF
--- a/src/vivarium_testing_utils/automated_validation/comparison.py
+++ b/src/vivarium_testing_utils/automated_validation/comparison.py
@@ -91,6 +91,10 @@ class FuzzyComparison(Comparison):
     ):
         self.measure: RatioMeasure = measure
         self.test_source = test_source
+        if not test_datasets.keys() == {"numerator", "denominator"}:
+            raise ValueError(
+                "test_datasets must be a dictionary with 'numerator' and 'denominator' keys."
+            )
         self.test_datasets = (
             test_datasets  # Dictionary with 'numerator' and 'denominator' keys
         )

--- a/src/vivarium_testing_utils/automated_validation/comparison.py
+++ b/src/vivarium_testing_utils/automated_validation/comparison.py
@@ -255,16 +255,14 @@ class FuzzyComparison(Comparison):
         # Drop any singular index levels from the reference data if they are not in the test data.
         # If any ref-only index level is not singular, raise an error.
         redundant_ref_indexes = get_singular_indices(self.reference_data).keys()
-        reference_data = self.reference_data.copy()
-        for index_name in ref_only_indexes:
-            if not index_name in redundant_ref_indexes:
-                # TODO: MIC-6075
-                raise ValueError(
-                    f"Reference data has non-trivial index {index_name} that is not in the test data."
-                    "We cannot currently marginalize over this index."
-                )
-            else:
-                reference_data = reference_data.droplevel(index_name)
+        if not set(ref_only_indexes).issubset(set(redundant_ref_indexes)):
+            # TODO: MIC-6075
+            diff = set(ref_only_indexes) - set(redundant_ref_indexes)
+            raise ValueError(
+                f"Reference data has non-trivial index levels {diff} that are not in the test data. "
+                "We cannot currently marginalize over these index levels."
+            )
+        reference_data = self.reference_data.droplevel(ref_only_indexes)
 
         converted_test_data = self.measure.get_measure_data_from_ratio(**test_datasets)
         return converted_test_data, reference_data

--- a/src/vivarium_testing_utils/automated_validation/comparison.py
+++ b/src/vivarium_testing_utils/automated_validation/comparison.py
@@ -262,16 +262,16 @@ class FuzzyComparison(Comparison):
             else:
                 reference_data = reference_data.droplevel(index_name)
 
-        converted_test_data = self.measure.get_measure_data_from_ratio(
-            self.test_data["numerator"], self.test_data["denominator"]
-        )
-
         # Apply marginalization to the converted test data
         test_only_indexes = [
             index
             for index in converted_test_data.index.names
             if index not in reference_data.index.names
         ]
-        stratified_converted_test_data = marginalize(converted_test_data, test_only_indexes)
+        stratified_numerator = marginalize(self.test_data["numerator"], test_only_indexes)
+        stratified_denominator = marginalize(self.test_data["denominator"], test_only_indexes)
 
-        return stratified_converted_test_data, reference_data
+        converted_test_data = self.measure.get_measure_data_from_ratio(
+            stratified_numerator, stratified_denominator
+        )
+        return converted_test_data, reference_data

--- a/src/vivarium_testing_utils/automated_validation/comparison.py
+++ b/src/vivarium_testing_utils/automated_validation/comparison.py
@@ -262,7 +262,10 @@ class FuzzyComparison(Comparison):
                 f"Reference data has non-trivial index levels {diff} that are not in the test data. "
                 "We cannot currently marginalize over these index levels."
             )
-        reference_data = self.reference_data.droplevel(ref_only_indexes)
+        reference_data = self.reference_data.droplevel(ref_only_indexes)  # type: ignore[arg-type]
+        # Mypy complains about list[str] being passed to droplevel, I think because list is invariabt
+        # and it wants list[Hashable]. That's an issue on the pandas side, not ours.
+        # Regardless, this is a valid use of the droplevel API.
 
         converted_test_data = self.measure.get_measure_data_from_ratio(**test_datasets)
         return converted_test_data, reference_data

--- a/src/vivarium_testing_utils/automated_validation/comparison.py
+++ b/src/vivarium_testing_utils/automated_validation/comparison.py
@@ -246,10 +246,10 @@ class FuzzyComparison(Comparison):
         ]
 
         # If the test data has any index levels that are not in the reference data, marginalize
-        # over those index levels.
-        test_datasets = self.test_datasets.copy()
+        # over those index levels.)
         test_datasets = {
-            key: marginalize(test_datasets[key], test_only_indexes) for key in test_datasets
+            key: marginalize(self.test_datasets[key], test_only_indexes)
+            for key in self.test_datasets
         }
 
         # Drop any singular index levels from the reference data if they are not in the test data.

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/age_groups.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/age_groups.py
@@ -14,7 +14,7 @@ AgeTuple = tuple[str, int | float, int | float]
 AgeRange = tuple[int | float, int | float]
 
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
-    RatioData,
+    SingleNumericColumn,
 )
 from vivarium_testing_utils.automated_validation.data_transformation.utils import check_io
 
@@ -458,7 +458,7 @@ def format_dataframe(target_schema: AgeSchema, df: pd.DataFrame) -> pd.DataFrame
         return data
 
 
-@check_io(df=RatioData)
+@check_io(df=SingleNumericColumn, out=SingleNumericColumn)
 def rebin_count_dataframe(
     target_schema: AgeSchema,
     df: pd.DataFrame,

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/age_groups.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/age_groups.py
@@ -446,15 +446,9 @@ def format_dataframe(target_schema: AgeSchema, df: pd.DataFrame) -> pd.DataFrame
             f"Rebinning DataFrame age groups from {source_age_schema} to {target_schema}."
         )
         # if we don't fit pandera schema SimOutputData, assume the data is rate data and raise an error.
-        try:
-            data = rebin_count_dataframe(
-                target_schema, df.droplevel([AGE_START_COLUMN, AGE_END_COLUMN])
-            )
-        except pa.errors.SchemaError:
-            # TODO: MIC-6075
-            raise NotImplementedError(
-                "Age Group rebinning can only be performed on count data."
-            )
+        data = rebin_count_dataframe(
+            target_schema, df.droplevel([AGE_START_COLUMN, AGE_END_COLUMN])
+        )
         return data
 
 

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
@@ -56,6 +56,11 @@ def filter_data(data: pd.DataFrame, filter_cols: dict[str, list[str]]) -> pd.Dat
     return data
 
 
+@check_io(
+    numerator_data=SingleNumericColumn,
+    denominator_data=SingleNumericColumn,
+    out=SingleNumericColumn,
+)
 def ratio(numerator_data: pd.DataFrame, denominator_data: pd.DataFrame) -> pd.DataFrame:
     """Return a DataFrame with the ratio of two DataFrames with 'value' columns.
 

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
@@ -56,18 +56,39 @@ def filter_data(data: pd.DataFrame, filter_cols: dict[str, list[str]]) -> pd.Dat
     return data
 
 
-def ratio(data: pd.DataFrame, numerator: str, denominator: str) -> pd.DataFrame:
-    """Return a series of the ratio of two columns in a DataFrame,
-    where the columns are specified by their names."""
-    zero_denominator = data[denominator] == 0
+def ratio(numerator_data: pd.DataFrame, denominator_data: pd.DataFrame) -> pd.DataFrame:
+    """Return a DataFrame with the ratio of two DataFrames with 'value' columns.
+
+    Parameters
+    ----------
+    numerator_data : pd.DataFrame
+        DataFrame with a 'value' column to use as the numerator
+    denominator_data : pd.DataFrame
+        DataFrame with a 'value' column to use as the denominator
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with a 'value' column containing the ratio values
+    """
+    if not numerator_data.index.equals(denominator_data.index):
+        raise ValueError("Numerator and denominator DataFrames must have identical indexes")
+
+    if "value" not in numerator_data.columns:
+        raise ValueError("Numerator DataFrame must have a 'value' column")
+
+    if "value" not in denominator_data.columns:
+        raise ValueError("Denominator DataFrame must have a 'value' column")
+
+    zero_denominator = denominator_data["value"] == 0
     if zero_denominator.any():
         logger.warning(
-            f"Denominator {denominator} has zero values. "
-            f"These will be put into the ratio dataframe as NaN."
+            "Denominator has zero values. "
+            "These will be put into the ratio dataframe as NaN."
         )
-    ratio = data[numerator] / data[denominator]
-    ratio[zero_denominator] = np.nan
-    return series_to_dataframe(ratio)
+    ratio_values = numerator_data["value"] / denominator_data["value"]
+    ratio_values[zero_denominator] = np.nan
+    return series_to_dataframe(ratio_values)
 
 
 def aggregate_sum(data: pd.DataFrame, groupby_cols: list[str]) -> pd.DataFrame:

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
@@ -62,19 +62,21 @@ def filter_data(data: pd.DataFrame, filter_cols: dict[str, list[str]]) -> pd.Dat
     out=SingleNumericColumn,
 )
 def ratio(numerator_data: pd.DataFrame, denominator_data: pd.DataFrame) -> pd.DataFrame:
-    """Return a DataFrame with the ratio of two DataFrames with 'value' columns.
+    """Return a DataFrame with the ratio of two SingleNumericColumn DataFrames.
+
+    Their indexes do not need to match, but must be interoperable.
 
     Parameters
     ----------
     numerator_data : pd.DataFrame
-        DataFrame with a 'value' column to use as the numerator
+        SingleNumericColumn DataFrame to use as the numerator
     denominator_data : pd.DataFrame
-        DataFrame with a 'value' column to use as the denominator
+        SingleNumericColumn DataFrame  to use as the denominator
 
     Returns
     -------
     pd.DataFrame
-        DataFrame with a 'value' column containing the ratio values
+        SingleNumericColumn DataFrame containing the ratio values
     """
     zero_denominator = denominator_data["value"] == 0
     if zero_denominator.any():

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/calculations.py
@@ -71,15 +71,6 @@ def ratio(numerator_data: pd.DataFrame, denominator_data: pd.DataFrame) -> pd.Da
     pd.DataFrame
         DataFrame with a 'value' column containing the ratio values
     """
-    if not numerator_data.index.equals(denominator_data.index):
-        raise ValueError("Numerator and denominator DataFrames must have identical indexes")
-
-    if "value" not in numerator_data.columns:
-        raise ValueError("Numerator DataFrame must have a 'value' column")
-
-    if "value" not in denominator_data.columns:
-        raise ValueError("Denominator DataFrame must have a 'value' column")
-
     zero_denominator = denominator_data["value"] == 0
     if zero_denominator.any():
         logger.warning(

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/data_schema.py
@@ -42,17 +42,3 @@ class DrawData(pa.DataFrameModel):
 
     class Config:
         strict = True
-
-
-class RatioData(pa.DataFrameModel):
-    """Ratio data is a dataframe with two numeric columns.
-
-    The columns will be numerator and denominator for a calculation into a final measure."""
-
-    # Custom Checks
-    @pa.dataframe_check
-    def check_two_numeric_columns(cls, df: pd.DataFrame) -> bool:
-        # Check that there are exactly two columns in the DataFrame,
-        # and both are numeric
-        numeric_columns = df.select_dtypes(include=["number"]).columns
-        return len(numeric_columns) == df.shape[1] == 2

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/formatting.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/formatting.py
@@ -23,16 +23,15 @@ class SimDataFormatter:
         ]
         self.filters = {"sub_entity": [filter_value]}
         self.filter_value = filter_value
-        self.new_value_column_name = f"{self.filter_value}_{self.measure}"
+        self.name = f"{self.filter_value}_{self.measure}"
 
     def format_dataset(self, dataset: pd.DataFrame) -> pd.DataFrame:
-        """Clean up unused columns, filter for the state, and rename the value column."""
+        """Clean up unused columns, filter for the state, and keep the value column as is."""
         dataset = marginalize(dataset, self.unused_columns)
         if self.filter_value == "total":
             dataset = marginalize(dataset, [*self.filters])
         else:
             dataset = filter_data(dataset, self.filters)
-        dataset = dataset.rename(columns={"value": self.new_value_column_name})
         return dataset
 
 
@@ -75,4 +74,4 @@ class Deaths(SimDataFormatter):
         self.unused_columns = ["measure", "entity_type"]
         self.filter_value = "total" if cause == "all_causes" else cause
         self.filters = {"entity": [self.filter_value], "sub_entity": [self.filter_value]}
-        self.new_value_column_name = f"{self.filter_value}_{self.measure}"
+        self.name = f"{self.filter_value}_{self.measure}"

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/formatting.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/formatting.py
@@ -26,7 +26,7 @@ class SimDataFormatter:
         self.name = f"{self.filter_value}_{self.measure}"
 
     def format_dataset(self, dataset: pd.DataFrame) -> pd.DataFrame:
-        """Clean up unused columns, filter for the state, and keep the value column as is."""
+        """Clean up unused columns, and filter for the state."""
         dataset = marginalize(dataset, self.unused_columns)
         if self.filter_value == "total":
             dataset = marginalize(dataset, [*self.filters])

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/measures.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/measures.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 import pandas as pd
-import pandera as pa
 
 from vivarium_testing_utils.automated_validation.data_loader import DataSource
 from vivarium_testing_utils.automated_validation.data_transformation.calculations import (
@@ -10,7 +9,6 @@ from vivarium_testing_utils.automated_validation.data_transformation.calculation
     ratio,
 )
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
-    RatioData,
     SimOutputData,
     SingleNumericColumn,
 )

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/measures.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/measures.py
@@ -106,18 +106,7 @@ class RatioMeasure(Measure, ABC):
         self, numerator_data: pd.DataFrame, denominator_data: pd.DataFrame
     ) -> pd.DataFrame:
         """Compute final measure data from separate numerator and denominator data."""
-        # Combine the data temporarily for the ratio calculation
-        # Rename columns to match what the ratio function expects
-        numerator_renamed = numerator_data.rename(columns={"value": self.numerator.name})
-        denominator_renamed = denominator_data.rename(
-            columns={"value": self.denominator.name}
-        )
-        ratio_data = pd.concat([numerator_renamed, denominator_renamed], axis=1)
-        return ratio(
-            ratio_data,
-            numerator=self.numerator.name,
-            denominator=self.denominator.name,
-        )
+        return ratio(numerator_data, denominator_data)
 
     @check_io(out=SingleNumericColumn)
     def get_measure_data_from_sim(self, *args: Any, **kwargs: Any) -> pd.DataFrame:

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/measures.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/measures.py
@@ -109,23 +109,24 @@ class RatioMeasure(Measure, ABC):
     @check_io(out=SingleNumericColumn)
     def get_measure_data_from_sim(self, *args: Any, **kwargs: Any) -> pd.DataFrame:
         """Process raw simulation data into a format suitable for calculations."""
-        numerator_data, denominator_data = self.get_ratio_data_from_sim(*args, **kwargs)
-        return self.get_measure_data_from_ratio(numerator_data, denominator_data)
+        return self.get_measure_data_from_ratio(
+            **self.get_ratio_datasets_from_sim(*args, **kwargs)
+        )
 
     @check_io(
         numerator_data=SimOutputData,
         denominator_data=SimOutputData,
     )
-    def get_ratio_data_from_sim(
+    def get_ratio_datasets_from_sim(
         self,
         numerator_data: pd.DataFrame,
         denominator_data: pd.DataFrame,
-    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+    ) -> dict[str, pd.DataFrame]:
         """Process raw simulation data and return numerator and denominator DataFrames separately."""
         numerator_data = self.numerator.format_dataset(numerator_data)
         denominator_data = self.denominator.format_dataset(denominator_data)
         numerator_data, denominator_data = align_indexes([numerator_data, denominator_data])
-        return numerator_data, denominator_data
+        return {"numerator_data": numerator_data, "denominator_data": denominator_data}
 
 
 class Incidence(RatioMeasure):

--- a/src/vivarium_testing_utils/automated_validation/interface.py
+++ b/src/vivarium_testing_utils/automated_validation/interface.py
@@ -65,19 +65,18 @@ class ValidationContext:
         numerator_data, denominator_data = measure.get_ratio_data_from_sim(
             **test_raw_datasets,
         )
-        # Combine numerator and denominator back into single DataFrame for compatibility
-        # Rename columns to use the formatter names before concatenating
-        numerator_renamed = numerator_data.rename(columns={"value": measure.numerator.name})
-        denominator_renamed = denominator_data.rename(
-            columns={"value": measure.denominator.name}
-        )
-        test_data = pd.concat([numerator_renamed, denominator_renamed], axis=1)
+        # Store test data as dictionary with separate numerator and denominator
+        test_data = {"numerator": numerator_data, "denominator": denominator_data}
 
         ref_source_enum = DataSource.from_str(ref_source)
         ref_raw_datasets = self._get_raw_datasets_from_source(measure, ref_source_enum)
         ref_data = measure.get_measure_data(ref_source_enum, **ref_raw_datasets)
 
-        test_data = resolve_age_groups(test_data, self.age_groups)
+        # Apply age group resolution to each component of test data and reference data
+        test_data["numerator"] = resolve_age_groups(test_data["numerator"], self.age_groups)
+        test_data["denominator"] = resolve_age_groups(
+            test_data["denominator"], self.age_groups
+        )
         ref_data = resolve_age_groups(ref_data, self.age_groups)
         comparison = FuzzyComparison(
             measure=measure,

--- a/src/vivarium_testing_utils/automated_validation/interface.py
+++ b/src/vivarium_testing_utils/automated_validation/interface.py
@@ -62,9 +62,16 @@ class ValidationContext:
                 f"Comparison for {test_source} source not implemented. Must be SIM."
             )
         test_raw_datasets = self._get_raw_datasets_from_source(measure, test_source_enum)
-        test_data = measure.get_ratio_data_from_sim(
+        numerator_data, denominator_data = measure.get_ratio_data_from_sim(
             **test_raw_datasets,
         )
+        # Combine numerator and denominator back into single DataFrame for compatibility
+        # Rename columns to use the formatter names before concatenating
+        numerator_renamed = numerator_data.rename(columns={"value": measure.numerator.name})
+        denominator_renamed = denominator_data.rename(
+            columns={"value": measure.denominator.name}
+        )
+        test_data = pd.concat([numerator_renamed, denominator_renamed], axis=1)
 
         ref_source_enum = DataSource.from_str(ref_source)
         ref_raw_datasets = self._get_raw_datasets_from_source(measure, ref_source_enum)

--- a/src/vivarium_testing_utils/automated_validation/interface.py
+++ b/src/vivarium_testing_utils/automated_validation/interface.py
@@ -62,26 +62,24 @@ class ValidationContext:
                 f"Comparison for {test_source} source not implemented. Must be SIM."
             )
         test_raw_datasets = self._get_raw_datasets_from_source(measure, test_source_enum)
-        numerator_data, denominator_data = measure.get_ratio_data_from_sim(
+        test_datasets = measure.get_ratio_data_from_sim(
             **test_raw_datasets,
         )
-        # Store test data as dictionary with separate numerator and denominator
-        test_data = {"numerator": numerator_data, "denominator": denominator_data}
 
         ref_source_enum = DataSource.from_str(ref_source)
         ref_raw_datasets = self._get_raw_datasets_from_source(measure, ref_source_enum)
         ref_data = measure.get_measure_data(ref_source_enum, **ref_raw_datasets)
 
         # Apply age group resolution to each component of test data and reference data
-        test_data["numerator"] = resolve_age_groups(test_data["numerator"], self.age_groups)
-        test_data["denominator"] = resolve_age_groups(
-            test_data["denominator"], self.age_groups
-        )
+        test_datasets = {
+            key: resolve_age_groups(data, self.age_groups)
+            for key, data in test_datasets.items()
+        }
         ref_data = resolve_age_groups(ref_data, self.age_groups)
         comparison = FuzzyComparison(
             measure=measure,
             test_source=test_source_enum,
-            test_datasets=test_data,
+            test_datasets=test_datasets,
             reference_source=ref_source_enum,
             reference_data=ref_data,
             stratifications=stratifications,

--- a/src/vivarium_testing_utils/automated_validation/interface.py
+++ b/src/vivarium_testing_utils/automated_validation/interface.py
@@ -62,7 +62,7 @@ class ValidationContext:
                 f"Comparison for {test_source} source not implemented. Must be SIM."
             )
         test_raw_datasets = self._get_raw_datasets_from_source(measure, test_source_enum)
-        test_datasets = measure.get_ratio_data_from_sim(
+        test_datasets = measure.get_ratio_datasets_from_sim(
             **test_raw_datasets,
         )
 

--- a/src/vivarium_testing_utils/automated_validation/interface.py
+++ b/src/vivarium_testing_utils/automated_validation/interface.py
@@ -81,7 +81,7 @@ class ValidationContext:
         comparison = FuzzyComparison(
             measure=measure,
             test_source=test_source_enum,
-            test_data=test_data,
+            test_datasets=test_data,
             reference_source=ref_source_enum,
             reference_data=ref_data,
             stratifications=stratifications,

--- a/tests/automated_validation/conftest.py
+++ b/tests/automated_validation/conftest.py
@@ -269,8 +269,7 @@ def sample_age_group_df() -> pd.DataFrame:
 def sample_df_with_ages() -> pd.DataFrame:
     return pd.DataFrame(
         {
-            "foo": [1.0, 2.0, 3.0],
-            "bar": [4.0, 5.0, 6.0],
+            "value": [1.0, 2.0, 3.0],
         },
         index=pd.MultiIndex.from_tuples(
             [

--- a/tests/automated_validation/data_transformation/test_age_groups.py
+++ b/tests/automated_validation/data_transformation/test_age_groups.py
@@ -284,18 +284,11 @@ def test_rebin_dataframe(sample_df_with_ages: pd.DataFrame) -> None:
         "4_to_7": 1.0 * 1 / 5 + 2.0 * 2 / 5,
         "7_to_15": 2.0 * 3 / 5 + 3.0,
     }
-    expected_bar = {
-        "0_to_3": 4.0 * 3 / 5,
-        "3_to_4": 4.0 * 1 / 5,
-        "4_to_7": 4.0 * 1 / 5 + 5.0 * 2 / 5,
-        "7_to_15": 5.0 * 3 / 5 + 6.0,
-    }
 
     rebinned_df = rebin_count_dataframe(target_age_schema, df)
     expected_df = pd.DataFrame(
         {
-            "foo": expected_foo.values(),
-            "bar": expected_bar.values(),
+            "value": expected_foo.values(),
         },
         index=pd.MultiIndex.from_tuples(
             [

--- a/tests/automated_validation/data_transformation/test_calculations.py
+++ b/tests/automated_validation/data_transformation/test_calculations.py
@@ -58,29 +58,6 @@ def test_ratio(intermediate_data: pd.DataFrame) -> None:
         pd.DataFrame({"value": [1.0, 2.0, np.nan, 4.0]}, index=intermediate_data.index),
     )
 
-    # Test mismatched indexes
-    mismatched_denominator = pd.DataFrame(
-        {"value": [1, 2]}, index=pd.Index(["a", "b"], name="different")
-    )
-    with pytest.raises(
-        ValueError, match="Numerator and denominator DataFrames must have identical indexes"
-    ):
-        ratio(numerator_a, mismatched_denominator)
-
-    # Test missing value column in numerator
-    bad_numerator = pd.DataFrame(
-        {"wrong_col": intermediate_data["a"]}, index=intermediate_data.index
-    )
-    with pytest.raises(ValueError, match="Numerator DataFrame must have a 'value' column"):
-        ratio(bad_numerator, denominator_b)
-
-    # Test missing value column in denominator
-    bad_denominator = pd.DataFrame(
-        {"wrong_col": intermediate_data["b"]}, index=intermediate_data.index
-    )
-    with pytest.raises(ValueError, match="Denominator DataFrame must have a 'value' column"):
-        ratio(numerator_a, bad_denominator)
-
 
 def test_aggregate_sum(intermediate_data: pd.DataFrame) -> None:
     """Test aggregating over different combinations of value columns."""

--- a/tests/automated_validation/data_transformation/test_data_schema.py
+++ b/tests/automated_validation/data_transformation/test_data_schema.py
@@ -5,7 +5,6 @@ from pandera.errors import SchemaError
 
 from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
     DrawData,
-    RatioData,
     SimOutputData,
     SingleNumericColumn,
 )
@@ -92,31 +91,3 @@ def test_draw_data(raw_artifact_disease_incidence: pd.DataFrame) -> None:
     wrong_dtype["draw_0"] = "invalid"
 
     check_schema_error_batch(DrawData, [extra_column_data, wrong_dtype])
-
-
-def test_ratio_data() -> None:
-    """
-    Test that the RatioData schema correctly validates a DataFrame with two numeric columns.
-    """
-    # Create a valid DataFrame
-    data = pd.DataFrame({"numerator": [1, 2, 3], "denominator": [4, 5, 6]})
-    RatioData.validate(data)
-
-    error_cases = []
-
-    # Test that the schema raises an error for extra columns
-    for extra_column_value in [0, "foo"]:
-        extra_column_data = data.copy()
-        extra_column_data["extra_column"] = extra_column_value
-        error_cases.append(extra_column_data)
-
-    # Test that the schema raises an error for invalid data
-    wrong_dtype = data.copy()
-    wrong_dtype["numerator"] = "invalid"
-
-    # Test that the schema raises an error for missing columns
-    missing_column_data = data.drop(columns=["numerator"])
-
-    error_cases.extend([missing_column_data, wrong_dtype])
-
-    check_schema_error_batch(RatioData, error_cases)

--- a/tests/automated_validation/data_transformation/test_formatting.py
+++ b/tests/automated_validation/data_transformation/test_formatting.py
@@ -18,15 +18,12 @@ def test_transition_counts(transition_count_data: pd.DataFrame) -> None:
     assert formatter.data_key == "transition_count_disease"
     assert formatter.filter_value == "susceptible_to_disease_to_disease"
     assert formatter.filters == {"sub_entity": ["susceptible_to_disease_to_disease"]}
-    assert (
-        formatter.new_value_column_name
-        == "susceptible_to_disease_to_disease_transition_count"
-    )
+    assert formatter.name == "susceptible_to_disease_to_disease_transition_count"
     assert formatter.unused_columns == ["measure", "entity_type", "entity"]
 
     expected_dataframe = pd.DataFrame(
         {
-            formatter.new_value_column_name: [3.0, 5.0],
+            "value": [3.0, 5.0],
         },
         index=pd.Index(
             ["A", "B"],
@@ -46,12 +43,12 @@ def test_person_time(person_time_data: pd.DataFrame) -> None:
     assert formatter.entity == "disease"
     assert formatter.data_key == "person_time_disease"
     assert formatter.filters == {"sub_entity": ["disease"]}
-    assert formatter.new_value_column_name == "disease_person_time"
+    assert formatter.name == "disease_person_time"
     assert formatter.unused_columns == ["measure", "entity_type", "entity"]
 
     expected_dataframe = pd.DataFrame(
         {
-            "disease_person_time": [23.0, 37.0],
+            "value": [23.0, 37.0],
         },
         index=pd.Index(
             ["A", "B"],
@@ -70,12 +67,12 @@ def test_person_time_state_total(person_time_data: pd.DataFrame) -> None:
     assert formatter.entity == "disease"
     assert formatter.data_key == "person_time_disease"
     assert formatter.filters == {"sub_entity": ["total"]}
-    assert formatter.new_value_column_name == "total_person_time"
+    assert formatter.name == "total_person_time"
     assert formatter.unused_columns == ["measure", "entity_type", "entity"]
 
     expected_dataframe = pd.DataFrame(
         {
-            "total_person_time": [17.0 + 23.0, 29.0 + 37.0],
+            "value": [17.0 + 23.0, 29.0 + 37.0],
         },
         index=pd.Index(
             ["A", "B"],
@@ -93,13 +90,13 @@ def test_total_person_time(total_person_time_data: pd.DataFrame) -> None:
     assert formatter.measure == "person_time"
     assert formatter.entity == "total"
     assert formatter.data_key == "person_time_total"
-    assert formatter.new_value_column_name == "total_person_time"
+    assert formatter.name == "total_person_time"
     assert formatter.unused_columns == ["measure", "entity_type", "entity"]
     assert formatter.filters == {"sub_entity": ["total"]}
 
     expected_dataframe = pd.DataFrame(
         {
-            "total_person_time": [17.0 + 23.0, 29.0 + 37.0],
+            "value": [17.0 + 23.0, 29.0 + 37.0],
         },
         index=pd.Index(
             ["A", "B"],
@@ -117,14 +114,14 @@ def test_deaths_cause_specific(deaths_data: pd.DataFrame) -> None:
     assert formatter.measure == "deaths"
     assert formatter.data_key == "deaths"
     assert formatter.filters == {"entity": ["disease"], "sub_entity": ["disease"]}
-    assert formatter.new_value_column_name == "disease_deaths"
+    assert formatter.name == "disease_deaths"
     assert formatter.unused_columns == ["measure", "entity_type"]
 
     # Filter out only data related to the disease itself, since we want
     # deaths directly attributed to the disease
     expected_dataframe = pd.DataFrame(
         {
-            "disease_deaths": [2.0, 4.0],  # Deaths data for the disease itself
+            "value": [2.0, 4.0],  # Deaths data for the disease itself
         },
         index=pd.Index(
             ["A", "B"],
@@ -142,12 +139,12 @@ def test_deaths_all_causes(deaths_data: pd.DataFrame) -> None:
     assert formatter.measure == "deaths"
     assert formatter.data_key == "deaths"
     assert formatter.filters == {"entity": ["total"], "sub_entity": ["total"]}
-    assert formatter.new_value_column_name == "total_deaths"
+    assert formatter.name == "total_deaths"
     assert formatter.unused_columns == ["measure", "entity_type"]
 
     expected_dataframe = pd.DataFrame(
         {
-            "total_deaths": [5.0, 9.0],  # All deaths, regardless of cause
+            "value": [5.0, 9.0],  # All deaths, regardless of cause
         },
         index=pd.Index(
             ["A", "B"],

--- a/tests/automated_validation/data_transformation/test_measures.py
+++ b/tests/automated_validation/data_transformation/test_measures.py
@@ -75,7 +75,7 @@ def test_prevalence(person_time_data: pd.DataFrame) -> None:
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    numerator_data, denominator_data = measure.get_ratio_datasets_from_sim(
+    ratio_datasets = measure.get_ratio_datasets_from_sim(
         numerator_data=person_time_data,
         denominator_data=person_time_data,
     )
@@ -97,11 +97,9 @@ def test_prevalence(person_time_data: pd.DataFrame) -> None:
             name="stratify_column",
         ),
     )
-    assert numerator_data.equals(expected_numerator_data)
-    assert denominator_data.equals(expected_denominator_data)
-    measure_data_from_ratio = measure.get_measure_data_from_ratio(
-        numerator_data=numerator_data, denominator_data=denominator_data
-    )
+    assert ratio_datasets["numerator_data"].equals(expected_numerator_data)
+    assert ratio_datasets["denominator_data"].equals(expected_denominator_data)
+    measure_data_from_ratio = measure.get_measure_data_from_ratio(**ratio_datasets)
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=person_time_data, denominator_data=person_time_data
     )
@@ -130,7 +128,7 @@ def test_si_remission(
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    numerator_data, denominator_data = measure.get_ratio_datasets_from_sim(
+    ratio_datasets = measure.get_ratio_datasets_from_sim(
         numerator_data=transition_count_data,
         denominator_data=person_time_data,
     )
@@ -153,11 +151,9 @@ def test_si_remission(
         ),
     )
 
-    assert numerator_data.equals(expected_numerator_data)
-    assert denominator_data.equals(expected_denominator_data)
-    measure_data_from_ratio = measure.get_measure_data_from_ratio(
-        numerator_data, denominator_data
-    )
+    assert ratio_datasets["numerator_data"].equals(expected_numerator_data)
+    assert ratio_datasets["denominator_data"].equals(expected_denominator_data)
+    measure_data_from_ratio = measure.get_measure_data_from_ratio(**ratio_datasets)
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=transition_count_data, denominator_data=person_time_data
     )
@@ -184,7 +180,7 @@ def test_all_cause_mortality_rate(
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    numerator_data, denominator_data = measure.get_ratio_datasets_from_sim(
+    ratio_datasets = measure.get_ratio_datasets_from_sim(
         numerator_data=deaths_data,
         denominator_data=total_person_time_data,
     )
@@ -213,8 +209,8 @@ def test_all_cause_mortality_rate(
             name="stratify_column",
         ),
     )
-    assert_frame_equal(numerator_data, expected_numerator_data)
-    assert_frame_equal(denominator_data, expected_denominator_data)
+    assert_frame_equal(ratio_datasets["numerator_data"], expected_numerator_data)
+    assert_frame_equal(ratio_datasets["denominator_data"], expected_denominator_data)
 
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=deaths_data, denominator_data=total_person_time_data
@@ -243,7 +239,7 @@ def test_cause_specific_mortality_rate(
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    numerator_data, denominator_data = measure.get_ratio_datasets_from_sim(
+    ratio_datasets = measure.get_ratio_datasets_from_sim(
         numerator_data=deaths_data,
         denominator_data=total_person_time_data,
     )
@@ -272,8 +268,8 @@ def test_cause_specific_mortality_rate(
             name="stratify_column",
         ),
     )
-    assert_frame_equal(numerator_data, expected_numerator_data)
-    assert_frame_equal(denominator_data, expected_denominator_data)
+    assert_frame_equal(ratio_datasets["numerator_data"], expected_numerator_data)
+    assert_frame_equal(ratio_datasets["denominator_data"], expected_denominator_data)
 
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=deaths_data, denominator_data=total_person_time_data
@@ -303,7 +299,7 @@ def test_excess_mortality_rate(
 
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    numerator_data, denominator_data = measure.get_ratio_datasets_from_sim(
+    ratio_datasets = measure.get_ratio_datasets_from_sim(
         numerator_data=deaths_data,
         denominator_data=person_time_data,
     )
@@ -332,8 +328,8 @@ def test_excess_mortality_rate(
             name="stratify_column",
         ),
     )
-    assert_frame_equal(numerator_data, expected_numerator_data)
-    assert_frame_equal(denominator_data, expected_denominator_data)
+    assert_frame_equal(ratio_datasets["numerator_data"], expected_numerator_data)
+    assert_frame_equal(ratio_datasets["denominator_data"], expected_denominator_data)
 
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=deaths_data, denominator_data=person_time_data

--- a/tests/automated_validation/data_transformation/test_measures.py
+++ b/tests/automated_validation/data_transformation/test_measures.py
@@ -1,9 +1,6 @@
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
-from vivarium_testing_utils.automated_validation.data_transformation.data_schema import (
-    RatioData,
-)
 from vivarium_testing_utils.automated_validation.data_transformation.measures import (
     CauseSpecificMortalityRate,
     ExcessMortalityRate,

--- a/tests/automated_validation/data_transformation/test_measures.py
+++ b/tests/automated_validation/data_transformation/test_measures.py
@@ -23,7 +23,7 @@ def test_incidence(
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    numerator_data, denominator_data = measure.get_ratio_data_from_sim(
+    ratio_datasets = measure.get_ratio_datasets_from_sim(
         numerator_data=transition_count_data,
         denominator_data=person_time_data,
     )
@@ -45,12 +45,10 @@ def test_incidence(
             name="stratify_column",
         ),
     )
-    assert numerator_data.equals(expected_numerator_data)
-    assert denominator_data.equals(expected_denominator_data)
+    assert ratio_datasets["numerator_data"].equals(expected_numerator_data)
+    assert ratio_datasets["denominator_data"].equals(expected_denominator_data)
 
-    measure_data_from_ratio = measure.get_measure_data_from_ratio(
-        numerator_data=numerator_data, denominator_data=denominator_data
-    )
+    measure_data_from_ratio = measure.get_measure_data_from_ratio(**ratio_datasets)
 
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=transition_count_data, denominator_data=person_time_data
@@ -77,7 +75,7 @@ def test_prevalence(person_time_data: pd.DataFrame) -> None:
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    numerator_data, denominator_data = measure.get_ratio_data_from_sim(
+    numerator_data, denominator_data = measure.get_ratio_datasets_from_sim(
         numerator_data=person_time_data,
         denominator_data=person_time_data,
     )
@@ -132,7 +130,7 @@ def test_si_remission(
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    numerator_data, denominator_data = measure.get_ratio_data_from_sim(
+    numerator_data, denominator_data = measure.get_ratio_datasets_from_sim(
         numerator_data=transition_count_data,
         denominator_data=person_time_data,
     )
@@ -186,7 +184,7 @@ def test_all_cause_mortality_rate(
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    numerator_data, denominator_data = measure.get_ratio_data_from_sim(
+    numerator_data, denominator_data = measure.get_ratio_datasets_from_sim(
         numerator_data=deaths_data,
         denominator_data=total_person_time_data,
     )
@@ -245,7 +243,7 @@ def test_cause_specific_mortality_rate(
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    numerator_data, denominator_data = measure.get_ratio_data_from_sim(
+    numerator_data, denominator_data = measure.get_ratio_datasets_from_sim(
         numerator_data=deaths_data,
         denominator_data=total_person_time_data,
     )
@@ -305,7 +303,7 @@ def test_excess_mortality_rate(
 
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    numerator_data, denominator_data = measure.get_ratio_data_from_sim(
+    numerator_data, denominator_data = measure.get_ratio_datasets_from_sim(
         numerator_data=deaths_data,
         denominator_data=person_time_data,
     )

--- a/tests/automated_validation/data_transformation/test_measures.py
+++ b/tests/automated_validation/data_transformation/test_measures.py
@@ -26,23 +26,34 @@ def test_incidence(
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    ratio_data = measure.get_ratio_data_from_sim(
+    numerator_data, denominator_data = measure.get_ratio_data_from_sim(
         numerator_data=transition_count_data,
         denominator_data=person_time_data,
     )
-    expected_ratio_data = pd.DataFrame(
+    expected_numerator_data = pd.DataFrame(
         {
-            "susceptible_to_disease_to_disease_transition_count": [3.0, 5.0],
-            "susceptible_to_disease_person_time": [17.0, 29.0],
+            "value": [3.0, 5.0],
         },
         index=pd.Index(
             ["A", "B"],
             name="stratify_column",
         ),
     )
-    assert ratio_data.equals(expected_ratio_data)
+    expected_denominator_data = pd.DataFrame(
+        {
+            "value": [17.0, 29.0],
+        },
+        index=pd.Index(
+            ["A", "B"],
+            name="stratify_column",
+        ),
+    )
+    assert numerator_data.equals(expected_numerator_data)
+    assert denominator_data.equals(expected_denominator_data)
 
-    measure_data_from_ratio = measure.get_measure_data_from_ratio(ratio_data=ratio_data)
+    measure_data_from_ratio = measure.get_measure_data_from_ratio(
+        numerator_data=numerator_data, denominator_data=denominator_data
+    )
 
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=transition_count_data, denominator_data=person_time_data
@@ -69,22 +80,33 @@ def test_prevalence(person_time_data: pd.DataFrame) -> None:
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    ratio_data = measure.get_ratio_data_from_sim(
+    numerator_data, denominator_data = measure.get_ratio_data_from_sim(
         numerator_data=person_time_data,
         denominator_data=person_time_data,
     )
-    expected_ratio_data = pd.DataFrame(
+    expected_numerator_data = pd.DataFrame(
         {
-            "disease_person_time": [23.0, 37.0],
-            "total_person_time": [17.0 + 23.0, 29.0 + 37.0],
+            "value": [23.0, 37.0],
         },
         index=pd.Index(
             ["A", "B"],
             name="stratify_column",
         ),
     )
-    assert ratio_data.equals(expected_ratio_data)
-    measure_data_from_ratio = measure.get_measure_data_from_ratio(ratio_data=ratio_data)
+    expected_denominator_data = pd.DataFrame(
+        {
+            "value": [17.0 + 23.0, 29.0 + 37.0],
+        },
+        index=pd.Index(
+            ["A", "B"],
+            name="stratify_column",
+        ),
+    )
+    assert numerator_data.equals(expected_numerator_data)
+    assert denominator_data.equals(expected_denominator_data)
+    measure_data_from_ratio = measure.get_measure_data_from_ratio(
+        numerator_data=numerator_data, denominator_data=denominator_data
+    )
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=person_time_data, denominator_data=person_time_data
     )
@@ -113,14 +135,22 @@ def test_si_remission(
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    ratio_data = measure.get_ratio_data_from_sim(
+    numerator_data, denominator_data = measure.get_ratio_data_from_sim(
         numerator_data=transition_count_data,
         denominator_data=person_time_data,
     )
-    expected_ratio_data = pd.DataFrame(
+    expected_numerator_data = pd.DataFrame(
         {
-            "disease_to_susceptible_to_disease_transition_count": [7.0, 13.0],
-            "disease_person_time": [23.0, 37.0],
+            "value": [7.0, 13.0],
+        },
+        index=pd.Index(
+            ["A", "B"],
+            name="stratify_column",
+        ),
+    )
+    expected_denominator_data = pd.DataFrame(
+        {
+            "value": [23.0, 37.0],
         },
         index=pd.Index(
             ["A", "B"],
@@ -128,8 +158,11 @@ def test_si_remission(
         ),
     )
 
-    assert ratio_data.equals(expected_ratio_data)
-    measure_data_from_ratio = measure.get_measure_data_from_ratio(ratio_data=ratio_data)
+    assert numerator_data.equals(expected_numerator_data)
+    assert denominator_data.equals(expected_denominator_data)
+    measure_data_from_ratio = measure.get_measure_data_from_ratio(
+        numerator_data, denominator_data
+    )
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=transition_count_data, denominator_data=person_time_data
     )
@@ -156,18 +189,26 @@ def test_all_cause_mortality_rate(
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    ratio_data = measure.get_ratio_data_from_sim(
+    numerator_data, denominator_data = measure.get_ratio_data_from_sim(
         numerator_data=deaths_data,
         denominator_data=total_person_time_data,
     )
 
-    # Expected dataframe for the ratio_data
+    # Expected dataframe for the numerator and denominator data
     # The Deaths formatter with no cause will marginalize over entity and sub_entity
     # to get total deaths by stratify_column
-    expected_ratio_data = pd.DataFrame(
+    expected_numerator_data = pd.DataFrame(
         {
-            "total_deaths": [5.0, 9.0],
-            "total_person_time": [
+            "value": [5.0, 9.0],
+        },
+        index=pd.Index(
+            ["A", "B"],
+            name="stratify_column",
+        ),
+    )
+    expected_denominator_data = pd.DataFrame(
+        {
+            "value": [
                 40.0,
                 66.0,
             ],
@@ -177,7 +218,8 @@ def test_all_cause_mortality_rate(
             name="stratify_column",
         ),
     )
-    assert_frame_equal(ratio_data, expected_ratio_data)
+    assert_frame_equal(numerator_data, expected_numerator_data)
+    assert_frame_equal(denominator_data, expected_denominator_data)
 
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=deaths_data, denominator_data=total_person_time_data
@@ -206,18 +248,26 @@ def test_cause_specific_mortality_rate(
     }
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    ratio_data = measure.get_ratio_data_from_sim(
+    numerator_data, denominator_data = measure.get_ratio_data_from_sim(
         numerator_data=deaths_data,
         denominator_data=total_person_time_data,
     )
 
-    # Expected dataframe for the ratio_data
+    # Expected dataframe for the numerator and denominator data
     # The Deaths formatter with a specific cause will filter for that cause
     # The TotalPersonTime formatter will marginalize person_time over all states
-    expected_ratio_data = pd.DataFrame(
+    expected_numerator_data = pd.DataFrame(
         {
-            "disease_deaths": [2.0, 4.0],
-            "total_person_time": [
+            "value": [2.0, 4.0],
+        },
+        index=pd.Index(
+            ["A", "B"],
+            name="stratify_column",
+        ),
+    )
+    expected_denominator_data = pd.DataFrame(
+        {
+            "value": [
                 40.0,
                 66.0,
             ],
@@ -227,7 +277,8 @@ def test_cause_specific_mortality_rate(
             name="stratify_column",
         ),
     )
-    assert_frame_equal(ratio_data, expected_ratio_data)
+    assert_frame_equal(numerator_data, expected_numerator_data)
+    assert_frame_equal(denominator_data, expected_denominator_data)
 
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=deaths_data, denominator_data=total_person_time_data
@@ -257,18 +308,26 @@ def test_excess_mortality_rate(
 
     assert measure.artifact_datasets == {"artifact_data": measure.measure_key}
 
-    ratio_data = measure.get_ratio_data_from_sim(
+    numerator_data, denominator_data = measure.get_ratio_data_from_sim(
         numerator_data=deaths_data,
         denominator_data=person_time_data,
     )
 
-    # Expected dataframe for the ratio_data
+    # Expected dataframe for the numerator and denominator data
     # The Deaths formatter with a specific cause will filter for that cause
     # The PersonTime formatter with a specific state will filter for that state
-    expected_ratio_data = pd.DataFrame(
+    expected_numerator_data = pd.DataFrame(
         {
-            "disease_deaths": [2.0, 4.0],
-            "disease_person_time": [
+            "value": [2.0, 4.0],
+        },
+        index=pd.Index(
+            ["A", "B"],
+            name="stratify_column",
+        ),
+    )
+    expected_denominator_data = pd.DataFrame(
+        {
+            "value": [
                 23.0,
                 37.0,
             ],
@@ -278,7 +337,8 @@ def test_excess_mortality_rate(
             name="stratify_column",
         ),
     )
-    assert_frame_equal(ratio_data, expected_ratio_data)
+    assert_frame_equal(numerator_data, expected_numerator_data)
+    assert_frame_equal(denominator_data, expected_denominator_data)
 
     measure_data = measure.get_measure_data_from_sim(
         numerator_data=deaths_data, denominator_data=person_time_data

--- a/tests/automated_validation/test_comparison.py
+++ b/tests/automated_validation/test_comparison.py
@@ -286,11 +286,11 @@ def test_fuzzy_comparison_align_datasets_with_singular_reference_index(
     assert singular_indices["location"] == "Global"
 
     # Execute
-    test_data, reference_data = comparison._align_datasets()
+    aligned_test_data, aligned_reference_data = comparison._align_datasets()
 
     # Verify the singular index was dropped
-    assert "location" not in reference_data.index.names
-    assert test_data.shape[0] == reference_data.shape[0]
+    assert "location" not in aligned_reference_data.index.names
+    assert aligned_test_data.shape[0] == aligned_reference_data.shape[0]
 
 
 def test_fuzzy_comparison_align_datasets_with_non_singular_reference_index(
@@ -346,6 +346,10 @@ def test_fuzzy_comparison_align_datasets_calculation(
 
     expected_values = [10 / 100, 20 / 100, (30 + 35) / (100 + 100)]
 
-    np.testing.assert_array_almost_equal(
-        aligned_test_data["value"].values, expected_values, decimal=10
+    assert_frame_equal(
+        aligned_test_data,
+        pd.DataFrame(
+            {"value": expected_values},
+            index=aligned_test_data.index,
+        ),
     )

--- a/tests/automated_validation/test_comparison.py
+++ b/tests/automated_validation/test_comparison.py
@@ -321,7 +321,9 @@ def test_fuzzy_comparison_align_datasets_with_non_singular_reference_index(
     assert "location" not in singular_indices
 
     # Execute and verify error is raised with correct message
-    with pytest.raises(ValueError, match="Reference data has non-trivial index location"):
+    with pytest.raises(
+        ValueError, match="Reference data has non-trivial index levels {'location'}"
+    ):
         comparison._align_datasets()
 
 

--- a/tests/automated_validation/test_comparison.py
+++ b/tests/automated_validation/test_comparison.py
@@ -98,7 +98,7 @@ def test_fuzzy_comparison_init(
     with check:
         assert comparison.measure == mock_ratio_measure
         assert comparison.test_source == DataSource.SIM
-        assert comparison.test_data == test_data
+        assert comparison.test_datasets == test_data
         assert comparison.reference_source == DataSource.GBD
         assert comparison.reference_data.equals(reference_data)
         assert list(comparison.stratifications) == []
@@ -294,7 +294,7 @@ def test_fuzzy_comparison_align_datasets_with_singular_reference_index(
 
     # Verify the singular index exists
     assert "location" in comparison.reference_data.index.names
-    assert "location" not in comparison.test_data["numerator"].index.names
+    assert "location" not in comparison.test_datasets["numerator"].index.names
 
     # Verify it's detected as a singular index
     singular_indices = get_singular_indices(comparison.reference_data)
@@ -330,7 +330,7 @@ def test_fuzzy_comparison_align_datasets_with_non_singular_reference_index(
 
     # Verify the non-singular index exists
     assert "location" in comparison.reference_data.index.names
-    assert "location" not in comparison.test_data["numerator"].index.names
+    assert "location" not in comparison.test_datasets["numerator"].index.names
 
     # Verify it's not detected as a singular index
     singular_indices = get_singular_indices(comparison.reference_data)

--- a/tests/automated_validation/test_comparison.py
+++ b/tests/automated_validation/test_comparison.py
@@ -120,7 +120,7 @@ def test_fuzzy_comparison_metadata(
         ("Measure Key", "mock_measure", "mock_measure"),
         ("Source", "sim", "gbd"),
         ("Index Columns", "year, sex, age, input_draw, random_seed", "year, sex, age"),
-        ("Size", "4 rows × 2 columns", "3 rows × 1 columns"),
+        ("Size", "4 rows × 1 columns", "3 rows × 1 columns"),
         ("Num Draws", "3", "N/A"),
         ("Input Draws", "[1, 2, 5]", "N/A"),
         ("Num Seeds", "3", "N/A"),
@@ -237,12 +237,12 @@ def test_get_metadata_from_dataset(
     comparison = FuzzyComparison(
         mock_ratio_measure, DataSource.SIM, test_data, DataSource.GBD, reference_data
     )
-    result = comparison._get_metadata_from_dataset("test")
+    result = comparison._get_metadata_from_datasets("test")
     with check:
         assert result["source"] == DataSource.SIM.value
         assert result["index_columns"] == "year, sex, age, input_draw, random_seed"
         assert (
-            result["size"] == "4 rows × 2 columns"
+            result["size"] == "4 rows × 1 columns"
         )  # 2 years * 2 sexes * 3 draws * 2 seeds = 24 rows, 1 column
         assert result["num_draws"] == "3"
         assert result["input_draws"] == "[1, 2, 5]"
@@ -262,7 +262,7 @@ def test_get_metadata_from_dataset_no_draws(
         DataSource.GBD,
         reference_data,
     )
-    result = comparison._get_metadata_from_dataset("reference")
+    result = comparison._get_metadata_from_datasets("reference")
     with check:
         assert result["source"] == DataSource.GBD.value
         assert result["index_columns"] == "year, sex, age"

--- a/tests/automated_validation/test_interface.py
+++ b/tests/automated_validation/test_interface.py
@@ -111,9 +111,9 @@ def test_add_comparison(
     assert comparison.stratifications == []
 
     # Test that test_data is now a dictionary with numerator and denominator
-    assert isinstance(comparison.test_data, dict)
-    assert "numerator" in comparison.test_data
-    assert "denominator" in comparison.test_data
+    assert isinstance(comparison.test_datasets, dict)
+    assert "numerator" in comparison.test_datasets
+    assert "denominator" in comparison.test_datasets
 
     expected_numerator_data = pd.DataFrame(
         {
@@ -134,8 +134,8 @@ def test_add_comparison(
         ),
     )
 
-    assert comparison.test_data["numerator"].equals(expected_numerator_data)
-    assert comparison.test_data["denominator"].equals(expected_denominator_data)
+    assert comparison.test_datasets["numerator"].equals(expected_numerator_data)
+    assert comparison.test_datasets["denominator"].equals(expected_denominator_data)
     assert comparison.reference_data.equals(artifact_disease_incidence)
 
 

--- a/tests/automated_validation/test_interface.py
+++ b/tests/automated_validation/test_interface.py
@@ -112,8 +112,8 @@ def test_add_comparison(
 
     # Test that test_data is now a dictionary with numerator and denominator
     assert isinstance(comparison.test_datasets, dict)
-    assert "numerator" in comparison.test_datasets
-    assert "denominator" in comparison.test_datasets
+    assert "numerator_data" in comparison.test_datasets
+    assert "denominator_data" in comparison.test_datasets
 
     expected_numerator_data = pd.DataFrame(
         {
@@ -134,8 +134,8 @@ def test_add_comparison(
         ),
     )
 
-    assert comparison.test_datasets["numerator"].equals(expected_numerator_data)
-    assert comparison.test_datasets["denominator"].equals(expected_denominator_data)
+    assert comparison.test_datasets["numerator_data"].equals(expected_numerator_data)
+    assert comparison.test_datasets["denominator_data"].equals(expected_denominator_data)
     assert comparison.reference_data.equals(artifact_disease_incidence)
 
 

--- a/tests/automated_validation/test_interface.py
+++ b/tests/automated_validation/test_interface.py
@@ -109,17 +109,33 @@ def test_add_comparison(
 
     assert comparison.measure.measure_key == measure_key
     assert comparison.stratifications == []
-    expected_ratio_data = pd.DataFrame(
+
+    # Test that test_data is now a dictionary with numerator and denominator
+    assert isinstance(comparison.test_data, dict)
+    assert "numerator" in comparison.test_data
+    assert "denominator" in comparison.test_data
+
+    expected_numerator_data = pd.DataFrame(
         {
-            "susceptible_to_disease_to_disease_transition_count": [3.0, 5.0],
-            "susceptible_to_disease_person_time": [17.0, 29.0],
+            "value": [3.0, 5.0],
         },
         index=pd.Index(
             ["A", "B"],
             name="stratify_column",
         ),
     )
-    assert comparison.test_data.equals(expected_ratio_data)
+    expected_denominator_data = pd.DataFrame(
+        {
+            "value": [17.0, 29.0],
+        },
+        index=pd.Index(
+            ["A", "B"],
+            name="stratify_column",
+        ),
+    )
+
+    assert comparison.test_data["numerator"].equals(expected_numerator_data)
+    assert comparison.test_data["denominator"].equals(expected_denominator_data)
     assert comparison.reference_data.equals(artifact_disease_incidence)
 
 


### PR DESCRIPTION
## Refactor ratiodata to just two dataframes
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6115

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
we want to be able to work with a numerator and denominator that might have different but interoperable index levels.
take the `pd.concat[numerator_data, denominator_data, axis=1)` and just break it up into two dataframes.
subsequently, refactor `ratio` calculation to take two dataframes, and remove now unneeded RatioData schema
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
I added a unit test where i encountered a silently failing issue.
