### PR TITLE
Albrja/mic 6065/update metadata

### DIFF
--- a/src/vivarium_testing_utils/automated_validation/interface.py
+++ b/src/vivarium_testing_utils/automated_validation/interface.py
@@ -186,8 +186,9 @@ class ValidationContext:
     def _get_directory_metadata(self) -> pd.DataFrame:
         """Add model run metadata to the dictionary."""
         sim_run_time = self.results_dir.name
-        # Format sim directory time to be same as artifact time: Month Day Hour:Minute
-        sim_dt = datetime.strptime(sim_run_time, "%Y_%m_%d_%H_%M_%S").strftime("%b %d %H:%M")
+        sim_dt = datetime.strptime(sim_run_time, "%Y_%m_%d_%H_%M_%S").strftime(
+            "%b %d %H:%M %Y"
+        )
         artifact_run_time = self._get_artifact_creation_time()
         directory_metadata = pd.DataFrame(
             {
@@ -207,7 +208,7 @@ class ValidationContext:
             ]["input_data"]["artifact_path"]
         )
         os_time = os.path.getmtime(artifact_path)
-        artifact_time = datetime.fromtimestamp(os_time).strftime("%b %d %H:%M")
+        artifact_time = datetime.fromtimestamp(os_time).strftime("%b %d %H:%M %Y")
 
         return artifact_time
 

--- a/tests/automated_validation/test_interface.py
+++ b/tests/automated_validation/test_interface.py
@@ -195,8 +195,8 @@ def test_metadata(sim_result_dir: Path, mocker: MockFixture) -> None:
         "Run Time",
     }
     # Metadata is already tesed with comparison and bundle. Run time is the only metadata from interface
-    assert metadata["Test Data"].loc["Run Time"] == "Jan 01 00:00"
-    assert metadata["Reference Data"]["Run Time"] == "Dec 31 23:59"
+    assert metadata["Test Data"].loc["Run Time"] == "Jan 01 00:00 2025"
+    assert metadata["Reference Data"]["Run Time"] == "Dec 31 23:59 2024"
 
 
 ######################################


### PR DESCRIPTION
## Albrja/mic 6065/update metadata

### Add metadata for simulation run time and artifact run time
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6065

### Changes and notes
-adds interface methods to get metadata for run time of simulation and artifacts

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

