### PR TITLE
Albrja/mic 6445/resolve age group column

### DIFF
--- a/src/vivarium_testing_utils/automated_validation/data_transformation/age_groups.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/age_groups.py
@@ -108,20 +108,22 @@ class AgeGroup:
         special_age_groups = {
             "early_neonatal": ("Early Neonatal", 0.0, 7 / 365.0),
             "late_neonatal": ("Late Neonatal", 7 / 365.0, 28 / 365.0),
+            # 1-5 months is not exactly 1 month so it is special cased
+            "1-5_months": ("1-5 Months", 28.0 / 365.0, 0.5),
             "95_plus": ("95 Plus", 95.0, 125.0),
         }
         if name in special_age_groups:
             special_name, start, end = special_age_groups[name]
             return cls(special_name, start, end)
         # Extract numbers and unit from the group name
-        pattern = r"(\d+(?:\.\d+)?)_to_(\d+(?:\.\d+)?)(?:_(\w+))?"
+        pattern = r"(\d+(?:\.\d+)?)(?:_to_|-)(\d+(?:\.\d+)?)(?:_(\w+))?"
         match = re.match(pattern, name.lower())
 
         if not match:
             raise ValueError(f"Invalid age group name format: {name}")
 
-        start, end, unit = match.groups()
-        start, end = float(start), float(end)
+        start_str, end_str, unit = match.groups()
+        start, end = float(start_str), float(end_str) + 1
 
         # Default to years if unit is not specified
         if unit is None:

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/age_groups.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/age_groups.py
@@ -109,8 +109,8 @@ class AgeGroup:
             "early_neonatal": ("Early Neonatal", 0.0, 7 / 365.0),
             "late_neonatal": ("Late Neonatal", 7 / 365.0, 28 / 365.0),
             # 1-5 months is not exactly 1 month so it is special cased
-            "1-5_months": ("1-5 Months", 28.0 / 365.0, 0.5),
-            "95_plus": ("95 Plus", 95.0, 125.0),
+            "1-5_months": ("1-5 months", 28.0 / 365.0, 0.5),
+            "95_plus": ("95 plus", 95.0, 125.0),
         }
         if name in special_age_groups:
             special_name, start, end = special_age_groups[name]

--- a/src/vivarium_testing_utils/automated_validation/data_transformation/age_groups.py
+++ b/src/vivarium_testing_utils/automated_validation/data_transformation/age_groups.py
@@ -104,6 +104,15 @@ class AgeGroup:
             ValueError
                 If the name does not match the expected format.
         """
+        # Special case for "early_neonatal", "late_neonatal", and "95_plus"
+        special_age_groups = {
+            "early_neonatal": ("Early Neonatal", 0.0, 7 / 365.0),
+            "late_neonatal": ("Late Neonatal", 7 / 365.0, 28 / 365.0),
+            "95_plus": ("95 Plus", 95.0, 125.0),
+        }
+        if name in special_age_groups:
+            special_name, start, end = special_age_groups[name]
+            return cls(special_name, start, end)
         # Extract numbers and unit from the group name
         pattern = r"(\d+(?:\.\d+)?)_to_(\d+(?:\.\d+)?)(?:_(\w+))?"
         match = re.match(pattern, name.lower())

--- a/tests/automated_validation/conftest.py
+++ b/tests/automated_validation/conftest.py
@@ -155,7 +155,7 @@ def _create_sample_age_group_df() -> pd.DataFrame:
     """Create sample age group data for testing."""
     return pd.DataFrame(
         {
-            AGE_GROUP_COLUMN: ["0_to_5", "5_to_10", "10_to_15"],
+            AGE_GROUP_COLUMN: ["0_to_4", "5_to_9", "10_to_14"],
             AGE_START_COLUMN: [0.0, 5.0, 10.0],
             AGE_END_COLUMN: [5.0, 10.0, 15.0],
         }
@@ -360,9 +360,9 @@ def artifact_disease_incidence() -> pd.DataFrame:
 @pytest.fixture
 def sample_age_tuples() -> list[AgeTuple]:
     return [
-        ("0_to_5", 0, 5),
-        ("5_to_10", 5, 10),
-        ("10_to_15", 10, 15),
+        ("0_to_4", 0, 5),
+        ("5_to_9", 5, 10),
+        ("10_to_14", 10, 15),
     ]
 
 
@@ -386,9 +386,9 @@ def sample_df_with_ages() -> pd.DataFrame:
         },
         index=pd.MultiIndex.from_tuples(
             [
-                ("cause", "disease", "0_to_5", 0.0, 5.0),
-                ("cause", "disease", "5_to_10", 5.0, 10.0),
-                ("cause", "disease", "10_to_15", 10.0, 15.0),
+                ("cause", "disease", "0_to_4", 0.0, 5.0),
+                ("cause", "disease", "5_to_9", 5.0, 10.0),
+                ("cause", "disease", "10_to_14", 10.0, 15.0),
             ],
             names=[
                 "cause",

--- a/tests/automated_validation/data_transformation/test_age_groups.py
+++ b/tests/automated_validation/data_transformation/test_age_groups.py
@@ -54,10 +54,10 @@ def test_age_group_eq() -> None:
 @pytest.mark.parametrize(
     "string, ages",
     [
-        ("0_to_5_years", (0, 5)),
-        ("0_to_6_months", (0, 0.5)),
-        ("0_to_8_days", (0, 0.02191780821917808)),
-        ("14_to_17", (14, 17)),
+        ("0_to_4_years", (0, 5)),
+        ("0_to_5_months", (0, 0.5)),
+        ("0_to_7_days", (0, 0.02191780821917808)),
+        ("14_to_16", (14, 17)),
     ],
 )
 def test_age_group_from_string(string: str, ages: AgeRange) -> None:
@@ -200,15 +200,15 @@ def test_age_schema_can_coerce_to() -> None:
 
 def test_age_schema_get_transform_matrix(sample_age_schema: AgeSchema) -> None:
     """Test we can get a transform matrix between two schemas."""
-    new_schema = AgeSchema.from_tuples([("0_to_7.5", 0, 7.5), ("7.5_to_15", 7.5, 15)])
+    new_schema = AgeSchema.from_tuples([("0_to_7.4", 0, 7.5), ("7.5_to_14", 7.5, 15)])
     transform_matrix = _get_transform_matrix(sample_age_schema, new_schema)
     expected_matrix = pd.DataFrame(
         {
-            "0_to_5": [1.0, 0.0],
-            "5_to_10": [0.5, 0.5],
-            "10_to_15": [0.0, 1.0],
+            "0_to_4": [1.0, 0.0],
+            "5_to_9": [0.5, 0.5],
+            "10_to_14": [0.0, 1.0],
         },
-        index=["0_to_7.5", "7.5_to_15"],
+        index=["0_to_7.4", "7.5_to_14"],
     )
 
     pd.testing.assert_frame_equal(transform_matrix, expected_matrix)
@@ -237,8 +237,8 @@ def test_age_schema_format_dataframe_invalid(sample_age_schema: AgeSchema) -> No
         },
         index=pd.MultiIndex.from_tuples(
             [
-                ("cause", "disease", "25_to_30"),
-                ("cause", "disease", "30_to_40"),
+                ("cause", "disease", "25_to_29"),
+                ("cause", "disease", "30_to_39"),
             ],
             names=["cause", "disease", AGE_GROUP_COLUMN],
         ),

--- a/tests/automated_validation/data_transformation/test_age_groups.py
+++ b/tests/automated_validation/data_transformation/test_age_groups.py
@@ -368,3 +368,37 @@ def test_resolve_special_age_groups() -> None:
     formatted_df = format_dataframe_from_age_bin_df(data, age_bins)
     context_age_schema = AgeSchema.from_dataframe(age_bins)
     pd.testing.assert_frame_equal(formatted_df, _format_dataframe(context_age_schema, data))
+
+    # Test older age groups for 95 plus special case
+    old_but_gold = pd.DataFrame(
+        {
+            "value": [1.0, 2.0, 3.0, 4.0],
+        },
+        index=pd.MultiIndex.from_tuples(
+            [
+                ("cause", "disease", "80_to_84"),
+                ("cause", "disease", "85_to_89"),
+                ("cause", "disease", "90_to_94"),
+                ("cause", "disease", "95_plus"),
+            ],
+            names=["measure", "entity", AGE_GROUP_COLUMN],
+        ),
+    )
+    oldies = pd.DataFrame(
+        {
+            AGE_GROUP_COLUMN: [
+                "80 to 84",
+                "85 to 89",
+                "90 to 94",
+                "95 plus",
+            ],
+            AGE_START_COLUMN: [80.0, 85.0, 90.0, 95.0],
+            AGE_END_COLUMN: [85.0, 90.0, 95.0, 125.0],
+        }
+    )
+    oldies = oldies.set_index([AGE_GROUP_COLUMN, AGE_START_COLUMN, AGE_END_COLUMN])
+    formatted_oldies = format_dataframe_from_age_bin_df(old_but_gold, oldies)
+    context_oldies_schema = AgeSchema.from_dataframe(oldies)
+    pd.testing.assert_frame_equal(
+        formatted_oldies, _format_dataframe(context_oldies_schema, old_but_gold)
+    )

--- a/tests/automated_validation/data_transformation/test_age_groups.py
+++ b/tests/automated_validation/data_transformation/test_age_groups.py
@@ -328,6 +328,7 @@ def test_format_dataframe_from_age_bin_df(
 def test_resolve_special_age_groups() -> None:
     """Test we can resolve special age groups."""
 
+    # Format of VPH observer outputs
     data = pd.DataFrame(
         {
             "value": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],


### PR DESCRIPTION
## Albrja/mic 6445/resolve age group column

### Update mapping of age group column
- *Category*: Implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6445

### Changes and notes
-updates how we resolve age group to match GBD age group name formatting and artifact format
-The typical GBD format for age group names is "2-4" and then "5-9" while the ages go from 2.0-4.99999 and so on. 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

