### PR TITLE
Add pytest-xdist auto-worker detection to pytest plugin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**0.5.0 - Unreleased**
+**0.5.0 - 03/30/26**
 
   - Feature: Add pytest-xdist auto-worker detection to pytest plugin.
     Repos opt in by adding ``addopts = "-nauto"`` to ``pyproject.toml``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+**0.5.0 - Unreleased**
+
+  - Feature: Add pytest-xdist auto-worker detection to pytest plugin.
+    Repos opt in by adding ``addopts = "-nauto"`` to ``pyproject.toml``.
+
 **0.4.0 - 03/27/26**
 
   - Phase 2 Automated Validation

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**0.5.0 - 03/30/26**
+**0.5.0 - 03/31/26**
 
   - Feature: Add pytest-xdist auto-worker detection to pytest plugin.
     Repos opt in by adding ``addopts = "-nauto"`` to ``pyproject.toml``.

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ if __name__ == "__main__":
         "pyarrow",
         "seaborn",
         "layered-config-tree",
+        "pytest-xdist",
         # Type stubs
         "types-setuptools",
     ]

--- a/src/vivarium_testing_utils/pytest_plugin.py
+++ b/src/vivarium_testing_utils/pytest_plugin.py
@@ -4,6 +4,7 @@ This module is automatically loaded by pytest when vivarium_testing_utils is ins
 via the pytest11 entry point defined in setup.py.
 """
 
+import os
 import shutil
 from datetime import datetime
 
@@ -59,6 +60,32 @@ def pytest_collection_modifyitems(config: Config, items: list[Function]) -> None
 def is_on_slurm() -> bool:
     """Returns True if the current environment is a SLURM cluster."""
     return shutil.which("sbatch") is not None
+
+
+IS_ON_SLURM = is_on_slurm()
+
+
+def pytest_xdist_auto_num_workers(config: Config) -> int:
+    """Automatically determine the number of workers for pytest-xdist.
+
+    - On SLURM: Use CPUs allocated to the job (via SLURM environment variables)
+    - Not on SLURM: Return 1 (no parallelization by default)
+    - Users can override by explicitly passing -n flag to pytest
+    """
+    cpus = 1
+    if IS_ON_SLURM:
+        # Check SLURM environment variables in order of preference
+        slurm_cpus = os.environ.get("SLURM_CPUS_PER_TASK") or os.environ.get(
+            "SLURM_CPUS_ON_NODE"
+        )
+        if slurm_cpus:
+            cpus = int(slurm_cpus)
+        # Fallback: use the number of CPUs actually available to this process
+        # (respects cgroup constraints set by SLURM)
+        else:
+            cpus = len(os.sched_getaffinity(0))
+
+    return cpus
 
 
 def is_slow_test_day(slow_test_day: str = SLOW_TEST_DAY) -> bool:

--- a/src/vivarium_testing_utils/pytest_plugin.py
+++ b/src/vivarium_testing_utils/pytest_plugin.py
@@ -15,6 +15,13 @@ from layered_config_tree import LayeredConfigTree
 from pytest_mock import MockerFixture
 
 SLOW_TEST_DAY = "Sunday"
+
+
+def is_on_slurm() -> bool:
+    """Returns True if the current environment is a SLURM cluster."""
+    return shutil.which("sbatch") is not None
+
+
 IS_ON_SLURM = is_on_slurm()
 
 
@@ -56,11 +63,6 @@ def pytest_collection_modifyitems(config: Config, items: list[Function]) -> None
         for item in items:
             if "weekly" in item.keywords:
                 item.add_marker(skip_weekly)
-
-
-def is_on_slurm() -> bool:
-    """Returns True if the current environment is a SLURM cluster."""
-    return shutil.which("sbatch") is not None
 
 
 def pytest_xdist_auto_num_workers(config: Config) -> int:

--- a/src/vivarium_testing_utils/pytest_plugin.py
+++ b/src/vivarium_testing_utils/pytest_plugin.py
@@ -15,6 +15,7 @@ from layered_config_tree import LayeredConfigTree
 from pytest_mock import MockerFixture
 
 SLOW_TEST_DAY = "Sunday"
+IS_ON_SLURM = is_on_slurm()
 
 
 def pytest_addoption(parser: argparsing.Parser) -> None:
@@ -41,7 +42,7 @@ def pytest_collection_modifyitems(config: Config, items: list[Function]) -> None
             if "slow" in item.keywords:
                 item.add_marker(skip_slow)
 
-    if not is_on_slurm():
+    if not IS_ON_SLURM:
         skip_cluster = pytest.mark.skip(reason="not running on SLURM cluster")
         for item in items:
             if "cluster" in item.keywords:
@@ -60,9 +61,6 @@ def pytest_collection_modifyitems(config: Config, items: list[Function]) -> None
 def is_on_slurm() -> bool:
     """Returns True if the current environment is a SLURM cluster."""
     return shutil.which("sbatch") is not None
-
-
-IS_ON_SLURM = is_on_slurm()
 
 
 def pytest_xdist_auto_num_workers(config: Config) -> int:


### PR DESCRIPTION
## Add pytest-xdist auto-worker detection to pytest plugin

### Description
- *Category*: feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6813

### Changes and notes

Moves the `pytest_xdist_auto_num_workers` hook (originally added in vivarium_gates_mncnh PR #273, bug-fixed in PR #299) into the shared VTU pytest plugin so all vivarium repos can benefit from automatic xdist parallelization.

**What changed:**
- Added `pytest-xdist` to `install_requires` in `setup.py`
- Added `pytest_xdist_auto_num_workers` hook to `pytest_plugin.py` that:
  - On SLURM: detects allocated CPUs via `SLURM_CPUS_PER_TASK` → `SLURM_CPUS_ON_NODE` → `os.sched_getaffinity(0)` fallback
  - Not on SLURM: returns 1 (no parallelization by default)
  - Users can always override with explicit `-n<NUM>`
- Reuses the existing `is_on_slurm()` helper already in the plugin

**How repos opt in:** Add `addopts = "-nauto"` to `pyproject.toml`. The hook is inert unless xdist is activated via `-nauto`.

### Testing

- The hook logic is ported from MNCNH where it has been tested on both local and SLURM environments
- Verified the `os.sched_getaffinity(0)` fallback correctly respects cgroup constraints (see MNCNH PR #299 for diagnostics)
