### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/pr_metrics.yml
+++ b/.github/workflows/pr_metrics.yml
@@ -31,7 +31,7 @@ jobs:
           echo "last_two_weeks=$fourteen_days_ago..$yesterday" >> "$GITHUB_ENV"
 
       - name: Get issue metrics for PRs closed in last sprint
-        uses: github/issue-metrics@v3
+        uses: github-community-projects/issue-metrics@v3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: $${{ env.REPO_LIST }} is:pr closed:${{ env.last_two_weeks }}
@@ -45,7 +45,7 @@ jobs:
           assignees: patricktnast
           
       - name: Get issue metrics for currently open PRs
-        uses: github/issue-metrics@v3
+        uses: github-community-projects/issue-metrics@v3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: '$${{ env.REPO_LIST }} is:pr is:open'


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/issue-metrics` | `github-community-projects/issue-metrics` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
