### PR TITLE
Use get_closest_marker instead of item.keywords

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.5.3- 05/05/26**
+
+  - Bugfix: Only skip for explicit marker calls with pytest plugin
+
 **0.5.2 - 04/16/26**
 
   - Tighten vivarium_build_utils pin

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**0.5.3- 05/05/26**
+**0.5.3 - 05/05/26**
 
   - Bugfix: Only skip for explicit marker calls with pytest plugin
 

--- a/src/vivarium_testing_utils/pytest_plugin.py
+++ b/src/vivarium_testing_utils/pytest_plugin.py
@@ -46,13 +46,13 @@ def pytest_collection_modifyitems(config: Config, items: list[Function]) -> None
     if not config.getoption("--runslow"):
         skip_slow = pytest.mark.skip(reason="need --runslow option to run")
         for item in items:
-            if "slow" in item.keywords:
+            if item.get_closest_marker("slow"):
                 item.add_marker(skip_slow)
 
     if not IS_ON_SLURM:
         skip_cluster = pytest.mark.skip(reason="not running on SLURM cluster")
         for item in items:
-            if "cluster" in item.keywords:
+            if item.get_closest_marker("cluster"):
                 item.add_marker(skip_cluster)
 
     # Weekly tests also require it to be the slow test day
@@ -61,7 +61,7 @@ def pytest_collection_modifyitems(config: Config, items: list[Function]) -> None
             reason="not the designated slow test day for weekly tests"
         )
         for item in items:
-            if "weekly" in item.keywords:
+            if item.get_closest_marker("weekly"):
                 item.add_marker(skip_weekly)
 
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -8,10 +8,14 @@ def test_test_in_slow_directory_not_skipped(pytester):
     skipped just because 'slow' appears in its keywords (path components).
     Only tests explicitly marked @pytest.mark.slow should be skipped."""
     pytester.mkdir("slow")
-    pytester.makepyfile(**{"slow/test_example.py": """
+    pytester.makepyfile(
+        **{
+            "slow/test_example.py": """
 def test_not_actually_slow(request):
     assert "slow" in request.keywords
-"""})
+"""
+        }
+    )
     result = pytester.runpytest("-v")
     result.stdout.fnmatch_lines(["*test_not_actually_slow PASSED*"])
     assert result.ret == 0

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,9 +1,11 @@
 """Regression tests for the pytest plugin."""
 
+import pytest
+
 pytest_plugins = ["pytester"]
 
 
-def test_test_in_slow_directory_not_skipped(pytester):
+def test_test_in_slow_directory_not_skipped(pytester: pytest.Pytester) -> None:
     """Regression test: a test located in a 'slow/' directory should NOT be
     skipped just because 'slow' appears in its keywords (path components).
     Only tests explicitly marked @pytest.mark.slow should be skipped."""

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,0 +1,17 @@
+"""Regression tests for the pytest plugin."""
+
+pytest_plugins = ["pytester"]
+
+
+def test_test_in_slow_directory_not_skipped(pytester):
+    """Regression test: a test located in a 'slow/' directory should NOT be
+    skipped just because 'slow' appears in its keywords (path components).
+    Only tests explicitly marked @pytest.mark.slow should be skipped."""
+    pytester.mkdir("slow")
+    pytester.makepyfile(**{"slow/test_example.py": """
+def test_not_actually_slow(request):
+    assert "slow" in request.keywords
+"""})
+    result = pytester.runpytest("-v")
+    result.stdout.fnmatch_lines(["*test_not_actually_slow PASSED*"])
+    assert result.ret == 0


### PR DESCRIPTION
## Use get_closest_marker instead of item.keywords
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-X7059

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Pytest automatically adds ancestor directory names as keywords to each test item. This can leave false skips, say if we have 'cluster' as a directory name but haven't explicitly marked the tests with the cluster label. we should use `item.get_closest_marker` instead of `item.keywords`
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
I will test this with VCT
